### PR TITLE
feat: research detail page + settings sidebar + global CSS refactor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,11 +12,13 @@
       "name": "backend",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.103.0",
         "cors": "^2.8.5",
       },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/cors": "^2.8.17",
+        "bun-types": "^1.3.12",
       },
       "peerDependencies": {
         "typescript": "^5",
@@ -26,6 +28,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.102.1",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -205,6 +208,20 @@
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
+    "@supabase/auth-js": ["@supabase/auth-js@2.103.0", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A=="],
+
+    "@supabase/functions-js": ["@supabase/functions-js@2.103.0", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-YrneV2NjskUkkmkZ2Jt2n3elBgbWzV4Y1M9MM370z2Zd5ZPFqFbY8KIoPwuNjtAGE9YrpKBxnbZqeF07BiN9Og=="],
+
+    "@supabase/phoenix": ["@supabase/phoenix@0.4.0", "", {}, "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw=="],
+
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.103.0", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-rC3sRxYdPZymkp2CZR1MiNQgbOleD01bGsW8VxEKRR5nMkLZ1NgAS1QTQf78Wh30czFyk505ZYr9Od8/mWT2TA=="],
+
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.103.0", "", { "dependencies": { "@supabase/phoenix": "^0.4.0", "@types/ws": "^8.18.1", "tslib": "2.8.1", "ws": "^8.18.2" } }, "sha512-gcPtXzZ6izyyBVf2of7K3dEt8CScPJn8VcSlQq6oWL9QoE1kqfQl0oFrOMHd5qrcADewxI7OxxosLB8W4XqtIQ=="],
+
+    "@supabase/storage-js": ["@supabase/storage-js@2.103.0", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-DHmlvdAXwtOmZNbkIZi4lkobPR3XjIzoOgzoz5duMf6G+sDeY015YrzMJCnqdccuYr7X5x4yYuSwF//RoN2dvQ=="],
+
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.103.0", "", { "dependencies": { "@supabase/auth-js": "2.103.0", "@supabase/functions-js": "2.103.0", "@supabase/postgrest-js": "2.103.0", "@supabase/realtime-js": "2.103.0", "@supabase/storage-js": "2.103.0" } }, "sha512-j/6q5+LtXbR/YOLSLhy7Na74RD1cV2v+KwIIuuqMEjk1JpLEEyu0ynwDHpGoxMncDQl+R5FogaVqZm+85lZvtw=="],
+
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.2.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.2" } }, "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA=="],
@@ -239,7 +256,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
-    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
 
@@ -254,6 +271,8 @@
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.57.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.57.2", "@typescript-eslint/type-utils": "8.57.2", "@typescript-eslint/utils": "8.57.2", "@typescript-eslint/visitor-keys": "8.57.2", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.57.2", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w=="],
 
@@ -365,7 +384,7 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": "cli.js" }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
-    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
@@ -552,6 +571,8 @@
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
+
+    "iceberg-js": ["iceberg-js@0.8.1", "", {}, "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -896,6 +917,8 @@
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 

--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -28,7 +28,7 @@ export default function LoginPage() {
     e.preventDefault();
     setLoading(true);
     setErrorMsg("");
-    
+
     const { error } = await supabase.auth.signInWithPassword({
       email,
       password,
@@ -98,23 +98,43 @@ export default function LoginPage() {
             }}
           >
             <svg width="18" height="18" viewBox="0 0 24 24">
-              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
-              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+              <path
+                fill="#4285F4"
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+              />
+              <path
+                fill="#34A853"
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              />
+              <path
+                fill="#FBBC05"
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+              />
+              <path
+                fill="#EA4335"
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              />
             </svg>
             Continue with Google
           </button>
 
           {/* Divider */}
-          <div className="divider-text" style={{ width: "100%", marginBottom: "28px" }}>
+          <div
+            className="divider-text"
+            style={{ width: "100%", marginBottom: "28px" }}
+          >
             <span>or</span>
           </div>
 
           {/* Login form */}
           <form
             onSubmit={handleSubmit}
-            style={{ width: "100%", display: "flex", flexDirection: "column", gap: "20px" }}
+            style={{
+              width: "100%",
+              display: "flex",
+              flexDirection: "column",
+              gap: "20px",
+            }}
           >
             <div>
               <label htmlFor="login-email" className="form-label">
@@ -132,8 +152,19 @@ export default function LoginPage() {
             </div>
 
             <div>
-              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "8px" }}>
-                <label htmlFor="login-password" className="form-label" style={{ margin: 0 }}>
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  marginBottom: "8px",
+                }}
+              >
+                <label
+                  htmlFor="login-password"
+                  className="form-label"
+                  style={{ margin: 0 }}
+                >
                   Password
                 </label>
                 <button
@@ -180,7 +211,16 @@ export default function LoginPage() {
                     display: "flex",
                   }}
                 >
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
                     {showPassword ? (
                       <>
                         <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
@@ -198,7 +238,14 @@ export default function LoginPage() {
             </div>
 
             {errorMsg && (
-              <div style={{ color: "var(--danger)", fontSize: "14px", marginTop: "-8px", textAlign: "center" }}>
+              <div
+                style={{
+                  color: "var(--danger)",
+                  fontSize: "14px",
+                  marginTop: "-8px",
+                  textAlign: "center",
+                }}
+              >
                 {errorMsg}
               </div>
             )}
@@ -207,7 +254,12 @@ export default function LoginPage() {
               type="submit"
               className="btn btn-primary"
               disabled={loading}
-              style={{ width: "100%", padding: "14px", fontSize: "15px", marginTop: "4px" }}
+              style={{
+                width: "100%",
+                padding: "14px",
+                fontSize: "15px",
+                marginTop: "4px",
+              }}
             >
               {loading ? (
                 <div
@@ -265,20 +317,46 @@ export default function LoginPage() {
               <div key={i} className="soundwave-bar" />
             ))}
           </div>
-          <span style={{ fontSize: "14px", fontWeight: 600, color: "var(--text-primary)" }}>Echo</span>
+          <span
+            style={{
+              fontSize: "14px",
+              fontWeight: 600,
+              color: "var(--text-primary)",
+            }}
+          >
+            Echo
+          </span>
         </div>
         <span style={{ fontSize: "12px", color: "var(--text-muted)" }}>
           &copy; 2026 Echo Research Lab
         </span>
         <div style={{ display: "flex", gap: "20px" }}>
-          <span style={{ fontSize: "12px", color: "var(--text-muted)", cursor: "pointer" }}>Documentation</span>
-          <span style={{ fontSize: "12px", color: "var(--text-muted)", cursor: "pointer" }}>Privacy</span>
+          <span
+            style={{
+              fontSize: "12px",
+              color: "var(--text-muted)",
+              cursor: "pointer",
+            }}
+          >
+            Documentation
+          </span>
+          <span
+            style={{
+              fontSize: "12px",
+              color: "var(--text-muted)",
+              cursor: "pointer",
+            }}
+          >
+            Privacy
+          </span>
         </div>
       </footer>
 
       <style jsx>{`
         @keyframes spin {
-          to { transform: rotate(360deg); }
+          to {
+            transform: rotate(360deg);
+          }
         }
       `}</style>
     </div>

--- a/frontend/app/auth/register/page.tsx
+++ b/frontend/app/auth/register/page.tsx
@@ -106,27 +106,54 @@ export default function RegisterPage() {
           {/* Google signup */}
           <button
             className="btn btn-secondary"
-            style={{ width: "100%", padding: "14px", fontSize: "15px", marginBottom: "28px" }}
+            style={{
+              width: "100%",
+              padding: "14px",
+              fontSize: "15px",
+              marginBottom: "28px",
+            }}
           >
             <svg width="18" height="18" viewBox="0 0 24 24">
-              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" />
-              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+              <path
+                fill="#4285F4"
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+              />
+              <path
+                fill="#34A853"
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              />
+              <path
+                fill="#FBBC05"
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+              />
+              <path
+                fill="#EA4335"
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              />
             </svg>
             Continue with Google
           </button>
 
-          <div className="divider-text" style={{ width: "100%", marginBottom: "28px" }}>
+          <div
+            className="divider-text"
+            style={{ width: "100%", marginBottom: "28px" }}
+          >
             <span>or</span>
           </div>
 
           <form
             onSubmit={handleSubmit}
-            style={{ width: "100%", display: "flex", flexDirection: "column", gap: "18px" }}
+            style={{
+              width: "100%",
+              display: "flex",
+              flexDirection: "column",
+              gap: "18px",
+            }}
           >
             <div>
-              <label htmlFor="register-name" className="form-label">Full Name</label>
+              <label htmlFor="register-name" className="form-label">
+                Full Name
+              </label>
               <input
                 id="register-name"
                 type="text"
@@ -139,7 +166,9 @@ export default function RegisterPage() {
             </div>
 
             <div>
-              <label htmlFor="register-email" className="form-label">Email Address</label>
+              <label htmlFor="register-email" className="form-label">
+                Email Address
+              </label>
               <input
                 id="register-email"
                 type="email"
@@ -152,7 +181,9 @@ export default function RegisterPage() {
             </div>
 
             <div>
-              <label htmlFor="register-password" className="form-label">Password</label>
+              <label htmlFor="register-password" className="form-label">
+                Password
+              </label>
               <div style={{ position: "relative" }}>
                 <input
                   id="register-password"
@@ -181,7 +212,16 @@ export default function RegisterPage() {
                     display: "flex",
                   }}
                 >
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
                     {showPassword ? (
                       <>
                         <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
@@ -215,13 +255,21 @@ export default function RegisterPage() {
                       flex: 1,
                       padding: "10px 8px",
                       borderRadius: "var(--radius-md)",
-                      border: `1.5px solid ${role === r.value ? "var(--primary)" : "var(--border)"}`,
-                      background: role === r.value ? "var(--primary-light)" : "var(--bg-surface)",
+                      border: `1.5px solid ${
+                        role === r.value ? "var(--primary)" : "var(--border)"
+                      }`,
+                      background:
+                        role === r.value
+                          ? "var(--primary-light)"
+                          : "var(--bg-surface)",
                       cursor: "pointer",
                       fontFamily: "inherit",
                       fontSize: "13px",
                       fontWeight: role === r.value ? 600 : 500,
-                      color: role === r.value ? "var(--primary-text)" : "var(--text-secondary)",
+                      color:
+                        role === r.value
+                          ? "var(--primary-text)"
+                          : "var(--text-secondary)",
                       transition: "all 150ms ease",
                     }}
                   >
@@ -232,7 +280,13 @@ export default function RegisterPage() {
             </div>
 
             {errorMsg && (
-              <div style={{ color: "var(--danger)", fontSize: "14px", textAlign: "center" }}>
+              <div
+                style={{
+                  color: "var(--danger)",
+                  fontSize: "14px",
+                  textAlign: "center",
+                }}
+              >
                 {errorMsg}
               </div>
             )}
@@ -241,7 +295,12 @@ export default function RegisterPage() {
               type="submit"
               className="btn btn-primary"
               disabled={loading}
-              style={{ width: "100%", padding: "14px", fontSize: "15px", marginTop: "4px" }}
+              style={{
+                width: "100%",
+                padding: "14px",
+                fontSize: "15px",
+                marginTop: "4px",
+              }}
             >
               {loading ? (
                 <div
@@ -259,8 +318,16 @@ export default function RegisterPage() {
               )}
             </button>
 
-            <p style={{ fontSize: "12px", color: "var(--text-muted)", textAlign: "center", lineHeight: 1.6 }}>
-              By creating an account, you agree to our Terms of Service and Privacy Policy
+            <p
+              style={{
+                fontSize: "12px",
+                color: "var(--text-muted)",
+                textAlign: "center",
+                lineHeight: 1.6,
+              }}
+            >
+              By creating an account, you agree to our Terms of Service and
+              Privacy Policy
             </p>
           </form>
 
@@ -302,18 +369,46 @@ export default function RegisterPage() {
               <div key={i} className="soundwave-bar" />
             ))}
           </div>
-          <span style={{ fontSize: "14px", fontWeight: 600, color: "var(--text-primary)" }}>Echo</span>
+          <span
+            style={{
+              fontSize: "14px",
+              fontWeight: 600,
+              color: "var(--text-primary)",
+            }}
+          >
+            Echo
+          </span>
         </div>
-        <span style={{ fontSize: "12px", color: "var(--text-muted)" }}>&copy; 2026 Echo Research Lab</span>
+        <span style={{ fontSize: "12px", color: "var(--text-muted)" }}>
+          &copy; 2026 Echo Research Lab
+        </span>
         <div style={{ display: "flex", gap: "20px" }}>
-          <span style={{ fontSize: "12px", color: "var(--text-muted)", cursor: "pointer" }}>Documentation</span>
-          <span style={{ fontSize: "12px", color: "var(--text-muted)", cursor: "pointer" }}>Privacy</span>
+          <span
+            style={{
+              fontSize: "12px",
+              color: "var(--text-muted)",
+              cursor: "pointer",
+            }}
+          >
+            Documentation
+          </span>
+          <span
+            style={{
+              fontSize: "12px",
+              color: "var(--text-muted)",
+              cursor: "pointer",
+            }}
+          >
+            Privacy
+          </span>
         </div>
       </footer>
 
       <style jsx>{`
         @keyframes spin {
-          to { transform: rotate(360deg); }
+          to {
+            transform: rotate(360deg);
+          }
         }
       `}</style>
     </div>

--- a/frontend/app/dashboard/campaigns/page.tsx
+++ b/frontend/app/dashboard/campaigns/page.tsx
@@ -1,100 +1,142 @@
 "use client";
 
-import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
 import ResearchCampaignModal from "@/app/new_compaign/create_compaign/ResearchCampaignModal";
 
-const campaigns = [
-  {
-    id: "1",
-    name: "User Onboarding Study",
-    description: "Understanding pain points in the first-time user experience for mobile app onboarding",
-    status: "active",
-    participants: 48,
-    completed: 31,
-    failed: 2,
-    avgDuration: "14m 23s",
-    createdAt: "Apr 6, 2026",
-    scheduledAt: "Apr 7, 2026 09:00",
-    questions: 8,
-  },
-  {
-    id: "2",
-    name: "Product Satisfaction Q2",
-    description: "Quarterly customer satisfaction interviews for enterprise clients",
-    status: "active",
-    participants: 120,
-    completed: 87,
-    failed: 5,
-    avgDuration: "11m 50s",
-    createdAt: "Apr 3, 2026",
-    scheduledAt: "Apr 4, 2026 10:00",
-    questions: 12,
-  },
-  {
-    id: "3",
-    name: "Feature Prioritization",
-    description: "Gathering user preferences on upcoming feature roadmap items",
-    status: "completed",
-    participants: 35,
-    completed: 35,
-    failed: 0,
-    avgDuration: "9m 12s",
-    createdAt: "Mar 28, 2026",
-    scheduledAt: "Mar 29, 2026 11:00",
-    questions: 6,
-  },
-  {
-    id: "4",
-    name: "Accessibility Feedback",
-    description: "Interviews with users who rely on assistive technologies",
-    status: "scheduled",
-    participants: 60,
-    completed: 0,
-    failed: 0,
-    avgDuration: "-",
-    createdAt: "Apr 8, 2026",
-    scheduledAt: "Apr 12, 2026 08:00",
-    questions: 10,
-  },
-  {
-    id: "5",
-    name: "Competitor Analysis Interviews",
-    description: "Understanding why users switched from competing products",
-    status: "paused",
-    participants: 25,
-    completed: 12,
-    failed: 1,
-    avgDuration: "16m 05s",
-    createdAt: "Mar 20, 2026",
-    scheduledAt: "Mar 21, 2026 14:00",
-    questions: 15,
-  },
-];
+// ── Types ─────────────────────────────────────────────────────────────────────
+interface Campaign {
+  id: string;
+  title: string;
+  description: string;
+  status: string;
+  campaign_id: string | null;
+  contact_list_file_name: string;
+  timeline_start: string;
+  timeline_end: string;
+  created_at: string;
+}
 
+interface CallStats {
+  total: number;
+  completed: number;
+  avgDurationSeconds: number;
+}
+
+// ── Status config ─────────────────────────────────────────────────────────────
 const statusConfig: Record<string, { label: string; className: string; dotClass: string }> = {
-  active: { label: "Active", className: "badge-success", dotClass: "status-dot-active" },
-  completed: { label: "Completed", className: "badge-info", dotClass: "" },
-  scheduled: { label: "Scheduled", className: "badge-warning", dotClass: "status-dot-pending" },
-  paused: { label: "Paused", className: "badge-neutral", dotClass: "" },
+  active:    { label: "Active",    className: "badge-success", dotClass: "status-dot-active"   },
+  completed: { label: "Completed", className: "badge-info",    dotClass: ""                    },
+  scheduled: { label: "Scheduled", className: "badge-warning", dotClass: "status-dot-pending"  },
+  paused:    { label: "Paused",    className: "badge-neutral", dotClass: ""                    },
+  draft:     { label: "Draft",     className: "badge-neutral", dotClass: ""                    },
+  archived:  { label: "Archived",  className: "badge-neutral", dotClass: ""                    },
 };
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function fmtDuration(seconds: number): string {
+  if (!seconds) return "—";
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}m ${s.toString().padStart(2, "0")}s`;
+}
+
+function fmtDate(d: string | null): string {
+  if (!d) return "—";
+  return new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+// ── Skeleton ──────────────────────────────────────────────────────────────────
+function CardSkeleton() {
+  return (
+    <div style={{
+      borderRadius: 12, border: "1px solid var(--border,#e5e7eb)",
+      padding: 24, background: "var(--bg-surface,#fff)",
+    }}>
+      <style>{`@keyframes shimmer{0%{background-position:-200% 0}100%{background-position:200% 0}}`}</style>
+      {[200, 140, 80].map((w, i) => (
+        <div key={i} style={{
+          height: i === 0 ? 18 : 14, width: `${w}px`, borderRadius: 6, marginBottom: 10,
+          background: "linear-gradient(90deg,#f3f4f6 25%,#e5e7eb 50%,#f3f4f6 75%)",
+          backgroundSize: "200% 100%", animation: "shimmer 1.5s ease-in-out infinite",
+        }} />
+      ))}
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
 export default function CampaignsPage() {
-  const [filter, setFilter] = useState("all");
+  const router = useRouter();
+
+  const [campaigns,  setCampaigns]  = useState<Campaign[]>([]);
+  const [callStats,  setCallStats]  = useState<Record<string, CallStats>>({});
+  const [loading,    setLoading]    = useState(true);
+  const [filter,     setFilter]     = useState("all");
   const [isCreateCampaignOpen, setIsCreateCampaignOpen] = useState(false);
 
-  const filtered = filter === "all" ? campaigns : campaigns.filter((c) => c.status === filter);
+  // ── Fetch ──────────────────────────────────────────────────────────────────
+  useEffect(() => {
+    const load = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) { router.push("/auth/login"); return; }
+
+      const { data, error } = await supabase
+        .from("research_campaigns")
+        .select("*")
+        .eq("user_id", session.user.id)
+        .order("created_at", { ascending: false });
+
+      if (error || !data) { setLoading(false); return; }
+      setCampaigns(data);
+
+      // Fetch call stats for each campaign that has a campaign_id
+      const stats: Record<string, CallStats> = {};
+      await Promise.all(
+        data
+          .filter((c: Campaign) => c.campaign_id)
+          .map(async (c: Campaign) => {
+            const { data: calls } = await supabase
+              .from("calls")
+              .select("id, status, duration_seconds")
+              .eq("campaign_id", c.campaign_id!);
+
+            const total     = calls?.length ?? 0;
+            const completed = calls?.filter(cl => cl.status === "completed").length ?? 0;
+            const totalSecs = calls?.reduce((sum, cl) => sum + (cl.duration_seconds ?? 0), 0) ?? 0;
+            const avgSecs   = completed > 0 ? Math.round(totalSecs / completed) : 0;
+
+            stats[c.id] = { total, completed, avgDurationSeconds: avgSecs };
+          })
+      );
+      setCallStats(stats);
+      setLoading(false);
+    };
+    load();
+  }, [router]);
+
+  // Re-fetch after modal closes (new campaign created)
+  const handleModalClose = async () => {
+    setIsCreateCampaignOpen(false);
+    setLoading(true);
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session) return;
+    const { data } = await supabase
+      .from("research_campaigns")
+      .select("*")
+      .eq("user_id", session.user.id)
+      .order("created_at", { ascending: false });
+    setCampaigns(data ?? []);
+    setLoading(false);
+  };
+
+  const filtered = filter === "all" ? campaigns : campaigns.filter(c => c.status === filter);
 
   return (
     <div className="animate-fade-in">
       {/* Header */}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "flex-start",
-          justifyContent: "space-between",
-          marginBottom: "28px",
-        }}
-      >
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", marginBottom: "28px" }}>
         <div>
           <h1 style={{ fontSize: "26px", fontWeight: 700, color: "var(--text-primary)", marginBottom: "6px" }}>
             Campaigns
@@ -116,176 +158,156 @@ export default function CampaignsPage() {
       </div>
 
       {/* Filters */}
-      <div
-        style={{
-          display: "flex",
-          gap: "8px",
-          marginBottom: "24px",
-        }}
-      >
+      <div style={{ display: "flex", gap: "8px", marginBottom: "24px", flexWrap: "wrap" }}>
         {[
-          { value: "all", label: "All", count: campaigns.length },
-          { value: "active", label: "Active", count: campaigns.filter((c) => c.status === "active").length },
-          { value: "scheduled", label: "Scheduled", count: campaigns.filter((c) => c.status === "scheduled").length },
-          { value: "completed", label: "Completed", count: campaigns.filter((c) => c.status === "completed").length },
-          { value: "paused", label: "Paused", count: campaigns.filter((c) => c.status === "paused").length },
-        ].map((f) => (
+          { value: "all",       label: "All",       count: campaigns.length },
+          { value: "active",    label: "Active",    count: campaigns.filter(c => c.status === "active").length },
+          { value: "scheduled", label: "Scheduled", count: campaigns.filter(c => c.status === "scheduled").length },
+          { value: "completed", label: "Completed", count: campaigns.filter(c => c.status === "completed").length },
+          { value: "paused",    label: "Paused",    count: campaigns.filter(c => c.status === "paused").length },
+        ].map(f => (
           <button
             key={f.value}
             onClick={() => setFilter(f.value)}
             style={{
-              padding: "8px 16px",
-              borderRadius: "var(--radius-full)",
-              fontSize: "13px",
-              fontWeight: 500,
-              border: "1.5px solid",
-              borderColor: filter === f.value ? "var(--primary)" : "var(--border)",
+              padding: "8px 16px", borderRadius: "var(--radius-full)", fontSize: "13px", fontWeight: 500,
+              border: "1.5px solid", borderColor: filter === f.value ? "var(--primary)" : "var(--border)",
               background: filter === f.value ? "var(--primary-subtle)" : "var(--bg-surface)",
               color: filter === f.value ? "var(--primary)" : "var(--text-secondary)",
-              cursor: "pointer",
-              fontFamily: "inherit",
-              transition: "all 150ms ease",
-              display: "flex",
-              alignItems: "center",
-              gap: "6px",
+              cursor: "pointer", fontFamily: "inherit", transition: "all 150ms ease",
+              display: "flex", alignItems: "center", gap: "6px",
             }}
           >
             {f.label}
-            <span
-              style={{
-                fontSize: "11px",
-                fontWeight: 700,
-                opacity: 0.7,
-              }}
-            >
-              {f.count}
-            </span>
+            <span style={{ fontSize: "11px", fontWeight: 700, opacity: 0.7 }}>{f.count}</span>
           </button>
         ))}
       </div>
 
       {/* Campaign cards */}
       <div className="stagger-children" style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
-        {filtered.map((campaign) => {
-          const progress = campaign.participants > 0 ? (campaign.completed / campaign.participants) * 100 : 0;
-          return (
-            <div
-              key={campaign.id}
-              className="card card-interactive"
-              style={{ padding: "24px", cursor: "pointer" }}
-            >
-              <div style={{ display: "flex", gap: "20px" }}>
-                {/* Main info */}
-                <div style={{ flex: 1 }}>
-                  <div style={{ display: "flex", alignItems: "center", gap: "12px", marginBottom: "8px" }}>
-                    <h3 style={{ fontSize: "16px", fontWeight: 600, color: "var(--text-primary)" }}>
-                      {campaign.name}
-                    </h3>
-                    <span className={`badge ${statusConfig[campaign.status]?.className}`}>
-                      {statusConfig[campaign.status]?.dotClass && (
-                        <span className={`status-dot ${statusConfig[campaign.status]?.dotClass}`} />
-                      )}
-                      {statusConfig[campaign.status]?.label}
-                    </span>
-                  </div>
-                  <p style={{ fontSize: "14px", color: "var(--text-secondary)", marginBottom: "20px", lineHeight: 1.5 }}>
-                    {campaign.description}
-                  </p>
+        {loading ? (
+          [1, 2, 3].map(i => <CardSkeleton key={i} />)
+        ) : filtered.length === 0 ? (
+          <div style={{
+            padding: "56px 32px", textAlign: "center",
+            background: "var(--bg-surface,#fff)", border: "1px solid var(--border,#e5e7eb)", borderRadius: 12,
+          }}>
+            <p style={{ fontSize: 15, fontWeight: 500, color: "var(--text-secondary)", margin: "0 0 4px" }}>
+              {campaigns.length === 0 ? "No campaigns yet" : "No campaigns match this filter"}
+            </p>
+            <p style={{ fontSize: 13, color: "var(--text-muted)", margin: "0 0 20px" }}>
+              {campaigns.length === 0
+                ? "Create your first research campaign to get started."
+                : "Try selecting a different filter above."}
+            </p>
+            {campaigns.length === 0 && (
+              <button
+                className="btn btn-primary"
+                style={{ padding: "10px 24px", fontSize: "14px" }}
+                onClick={() => setIsCreateCampaignOpen(true)}
+              >
+                + New Campaign
+              </button>
+            )}
+          </div>
+        ) : (
+          filtered.map(campaign => {
+            const stats    = callStats[campaign.id] ?? { total: 0, completed: 0, avgDurationSeconds: 0 };
+            const progress = stats.total > 0 ? (stats.completed / stats.total) * 100 : 0;
 
-                  {/* Meta row */}
-                  <div style={{ display: "flex", gap: "24px", flexWrap: "wrap" }}>
-                    {[
-                      {
-                        icon: "M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z",
-                        label: `${campaign.participants} participants`,
-                      },
-                      {
-                        icon: "M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z",
-                        label: `${campaign.questions} questions`,
-                      },
-                      {
-                        icon: "M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z",
-                        label: `Avg. ${campaign.avgDuration}`,
-                      },
-                      {
-                        icon: "M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z",
-                        label: campaign.createdAt,
-                      },
-                    ].map(({ icon, label }) => (
-                      <div
-                        key={label}
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: "6px",
-                          fontSize: "13px",
-                          color: "var(--text-muted)",
-                        }}
-                      >
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-                          <path d={icon} />
-                        </svg>
-                        {label}
-                      </div>
-                    ))}
-                  </div>
-                </div>
+            return (
+              <div
+                key={campaign.id}
+                className="card card-interactive"
+                style={{ padding: "24px", cursor: "pointer" }}
+                onClick={() => router.push(`/dashboard/research/${campaign.id}`)}
+              >
+                <div style={{ display: "flex", gap: "20px" }}>
+                  {/* Main info */}
+                  <div style={{ flex: 1 }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: "12px", marginBottom: "8px" }}>
+                      <h3 style={{ fontSize: "16px", fontWeight: 600, color: "var(--text-primary)" }}>
+                        {campaign.title}
+                      </h3>
+                      <span className={`badge ${statusConfig[campaign.status]?.className ?? "badge-neutral"}`}>
+                        {statusConfig[campaign.status]?.dotClass && (
+                          <span className={`status-dot ${statusConfig[campaign.status]?.dotClass}`} />
+                        )}
+                        {statusConfig[campaign.status]?.label ?? campaign.status}
+                      </span>
+                    </div>
+                    <p style={{ fontSize: "14px", color: "var(--text-secondary)", marginBottom: "20px", lineHeight: 1.5 }}>
+                      {campaign.description}
+                    </p>
 
-                {/* Progress ring */}
-                <div
-                  style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    gap: "8px",
-                    minWidth: "100px",
-                  }}
-                >
-                  <div style={{ position: "relative", width: "72px", height: "72px" }}>
-                    <svg width="72" height="72" viewBox="0 0 72 72" style={{ transform: "rotate(-90deg)" }}>
-                      <circle cx="36" cy="36" r="30" fill="none" stroke="var(--bg-muted)" strokeWidth="6" />
-                      <circle
-                        cx="36"
-                        cy="36"
-                        r="30"
-                        fill="none"
-                        stroke={campaign.status === "completed" ? "var(--success)" : "var(--primary)"}
-                        strokeWidth="6"
-                        strokeDasharray={`${2 * Math.PI * 30}`}
-                        strokeDashoffset={`${2 * Math.PI * 30 * (1 - progress / 100)}`}
-                        strokeLinecap="round"
-                        style={{ transition: "stroke-dashoffset 800ms ease" }}
-                      />
-                    </svg>
-                    <div
-                      style={{
-                        position: "absolute",
-                        inset: 0,
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        fontSize: "16px",
-                        fontWeight: 700,
-                        color: "var(--text-primary)",
-                      }}
-                    >
-                      {Math.round(progress)}%
+                    {/* Meta row */}
+                    <div style={{ display: "flex", gap: "24px", flexWrap: "wrap" }}>
+                      {[
+                        {
+                          icon: "M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z",
+                          label: `${stats.total} calls`,
+                        },
+                        {
+                          icon: "M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z",
+                          label: `${stats.completed} completed`,
+                        },
+                        {
+                          icon: "M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z",
+                          label: stats.avgDurationSeconds > 0 ? `Avg. ${fmtDuration(stats.avgDurationSeconds)}` : "No calls yet",
+                        },
+                        {
+                          icon: "M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z",
+                          label: fmtDate(campaign.created_at),
+                        },
+                      ].map(({ icon, label }) => (
+                        <div key={label} style={{ display: "flex", alignItems: "center", gap: "6px", fontSize: "13px", color: "var(--text-muted)" }}>
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                            <path d={icon} />
+                          </svg>
+                          {label}
+                        </div>
+                      ))}
                     </div>
                   </div>
-                  <span style={{ fontSize: "12px", color: "var(--text-muted)" }}>
-                    {campaign.completed}/{campaign.participants}
-                  </span>
+
+                  {/* Progress ring */}
+                  <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: "8px", minWidth: "100px" }}>
+                    <div style={{ position: "relative", width: "72px", height: "72px" }}>
+                      <svg width="72" height="72" viewBox="0 0 72 72" style={{ transform: "rotate(-90deg)" }}>
+                        <circle cx="36" cy="36" r="30" fill="none" stroke="var(--bg-muted)" strokeWidth="6" />
+                        <circle
+                          cx="36" cy="36" r="30" fill="none"
+                          stroke={campaign.status === "completed" ? "var(--success)" : "var(--primary)"}
+                          strokeWidth="6"
+                          strokeDasharray={`${2 * Math.PI * 30}`}
+                          strokeDashoffset={`${2 * Math.PI * 30 * (1 - progress / 100)}`}
+                          strokeLinecap="round"
+                          style={{ transition: "stroke-dashoffset 800ms ease" }}
+                        />
+                      </svg>
+                      <div style={{
+                        position: "absolute", inset: 0,
+                        display: "flex", alignItems: "center", justifyContent: "center",
+                        fontSize: "16px", fontWeight: 700, color: "var(--text-primary)",
+                      }}>
+                        {Math.round(progress)}%
+                      </div>
+                    </div>
+                    <span style={{ fontSize: "12px", color: "var(--text-muted)" }}>
+                      {stats.completed}/{stats.total}
+                    </span>
+                  </div>
                 </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })
+        )}
       </div>
 
       <ResearchCampaignModal
         isOpen={isCreateCampaignOpen}
-        onClose={() => setIsCreateCampaignOpen(false)}
+        onClose={handleModalClose}
       />
     </div>
   );

--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -34,9 +34,30 @@ const navItems = [
     label: "Analytics",
     icon: "M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z",
   },
+  {
+    href: "/dashboard/settings",
+    label: "Settings",
+    icon: "M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z",
+  },
 ];
 
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function getInitials(name: string | null, email: string) {
+  if (name?.trim())
+    return name
+      .split(" ")
+      .map((n) => n[0])
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+  return email.slice(0, 2).toUpperCase();
+}
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const pathname = usePathname();
   const router = useRouter();
   const [collapsed, setCollapsed] = useState(false);
@@ -46,22 +67,22 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 
   useEffect(() => {
     const fetchUser = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
       if (!session) {
         router.push("/auth/login");
         return;
       }
       setUser(session.user);
-      
+
       const { data: profileData } = await supabase
         .from("profiles")
         .select("*")
         .eq("id", session.user.id)
         .single();
-        
-      if (profileData) {
-        setProfile(profileData);
-      }
+
+      if (profileData) setProfile(profileData);
     };
     fetchUser();
   }, [router]);
@@ -73,9 +94,18 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   const isActive = (href: string, exact?: boolean) =>
     exact ? pathname === href : pathname.startsWith(href);
 
+  const displayName =
+    profile?.full_name || user?.user_metadata?.full_name || null;
+  const isSettingsActive = pathname.startsWith("/dashboard/settings");
+
   return (
-    <div style={{ display: "flex", minHeight: "100vh", background: "var(--bg-base)" }}>
-      {/* Sidebar — light */}
+    <div
+      style={{
+        display: "flex",
+        minHeight: "100vh",
+        background: "var(--bg-base)",
+      }}
+    >
       <aside
         style={{
           width: collapsed ? "72px" : "260px",
@@ -92,7 +122,6 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           zIndex: 50,
         }}
       >
-        {/* Logo */}
         <div
           style={{
             padding: collapsed ? "20px 16px" : "20px 24px",
@@ -102,18 +131,37 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
             borderBottom: "1px solid var(--sidebar-border)",
           }}
         >
-          <div className="soundwave soundwave-sm soundwave-static" style={{ flexShrink: 0 }}>
+          <div
+            className="soundwave soundwave-sm soundwave-static"
+            style={{ flexShrink: 0 }}
+          >
             {Array.from({ length: 7 }).map((_, i) => (
               <div key={i} className="soundwave-bar" />
             ))}
           </div>
           {!collapsed && (
-            <span style={{ fontSize: "20px", fontWeight: 700, color: "var(--text-primary)" }}>Echo</span>
+            <span
+              style={{
+                fontSize: "20px",
+                fontWeight: 700,
+                color: "var(--text-primary)",
+              }}
+            >
+              Echo
+            </span>
           )}
         </div>
 
-        {/* Nav items */}
-        <nav style={{ flex: 1, padding: "16px 12px", display: "flex", flexDirection: "column", gap: "2px" }}>
+        <nav
+          style={{
+            flex: 1,
+            padding: "16px 12px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "2px",
+            overflowY: "auto",
+          }}
+        >
           {navItems.map((item) => {
             const active = isActive(item.href, item.exact);
             return (
@@ -163,16 +211,34 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                     }}
                   />
                 )}
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.8"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  style={{ flexShrink: 0 }}
+                >
                   <path d={item.icon} />
                 </svg>
                 {!collapsed && <span>{item.label}</span>}
                 {!collapsed && item.badge && (
-                  <span style={{
-                    marginLeft: "auto", background: "var(--primary)", color: "#fff",
-                    fontSize: "11px", fontWeight: 700, padding: "2px 8px",
-                    borderRadius: "var(--radius-full)", minWidth: "20px", textAlign: "center",
-                  }}>
+                  <span
+                    style={{
+                      marginLeft: "auto",
+                      background: "var(--primary)",
+                      color: "#fff",
+                      fontSize: "11px",
+                      fontWeight: 700,
+                      padding: "2px 8px",
+                      borderRadius: "var(--radius-full)",
+                      minWidth: "20px",
+                      textAlign: "center",
+                    }}
+                  >
                     {item.badge}
                   </span>
                 )}
@@ -181,91 +247,221 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           })}
         </nav>
 
-        {/* Bottom */}
-        <div style={{ padding: "12px", borderTop: "1px solid var(--sidebar-border)" }}>
+        <div
+          style={{
+            padding: "12px",
+            borderTop: "1px solid var(--sidebar-border)",
+          }}
+        >
           <button
             onClick={() => setCollapsed(!collapsed)}
             style={{
-              display: "flex", alignItems: "center", gap: "12px",
-              padding: collapsed ? "10px" : "10px 14px", borderRadius: "var(--radius-sm)",
-              background: "transparent", color: "var(--sidebar-text)",
-              border: "none", cursor: "pointer", fontSize: "13px", fontFamily: "inherit",
-              width: "100%", justifyContent: collapsed ? "center" : "flex-start",
+              display: "flex",
+              alignItems: "center",
+              gap: "12px",
+              padding: collapsed ? "10px" : "10px 14px",
+              borderRadius: "var(--radius-sm)",
+              background: "transparent",
+              color: "var(--sidebar-text)",
+              border: "none",
+              cursor: "pointer",
+              fontSize: "13px",
+              fontFamily: "inherit",
+              width: "100%",
+              justifyContent: collapsed ? "center" : "flex-start",
               transition: "all 150ms ease",
             }}
-            onMouseEnter={(e) => { e.currentTarget.style.background = "var(--sidebar-hover)"; }}
-            onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = "var(--sidebar-hover)";
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = "transparent";
+            }}
           >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"
-              style={{ flexShrink: 0, transform: collapsed ? "rotate(180deg)" : "none", transition: "transform 250ms ease" }}>
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              style={{
+                flexShrink: 0,
+                transform: collapsed ? "rotate(180deg)" : "none",
+                transition: "transform 250ms ease",
+              }}
+            >
               <path d="M11 19l-7-7 7-7M18 19l-7-7 7-7" />
             </svg>
             {!collapsed && <span>Collapse</span>}
           </button>
 
-          <div
+          <Link
+            href="/dashboard/settings"
             style={{
-              display: "flex", alignItems: "center", gap: "10px",
-              padding: collapsed ? "10px" : "10px 14px", borderRadius: "var(--radius-sm)",
-              marginTop: "4px", justifyContent: collapsed ? "center" : "flex-start",
-              cursor: "pointer", transition: "all 150ms ease",
+              display: "flex",
+              alignItems: "center",
+              gap: "10px",
+              padding: collapsed ? "10px" : "10px 14px",
+              borderRadius: "var(--radius-sm)",
+              marginTop: "4px",
+              justifyContent: collapsed ? "center" : "flex-start",
+              textDecoration: "none",
+              background: isSettingsActive
+                ? "var(--sidebar-active)"
+                : "transparent",
+              transition: "all 150ms ease",
             }}
-            onMouseEnter={(e) => { e.currentTarget.style.background = "var(--sidebar-hover)"; }}
-            onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
+            title={collapsed ? "Settings" : undefined}
+            onMouseEnter={(e) => {
+              if (!isSettingsActive) {
+                e.currentTarget.style.background = "var(--sidebar-hover)";
+              }
+            }}
+            onMouseLeave={(e) => {
+              if (!isSettingsActive) {
+                e.currentTarget.style.background = "transparent";
+              }
+            }}
           >
-            <div style={{
-              width: "32px", height: "32px", borderRadius: "50%",
-              background: "linear-gradient(135deg, var(--primary), var(--primary-hover))",
-              display: "flex", alignItems: "center", justifyContent: "center",
-              fontSize: "13px", fontWeight: 700, color: "#fff", flexShrink: 0,
-            }}>
-              DR
+            <div
+              style={{
+                width: "32px",
+                height: "32px",
+                borderRadius: "50%",
+                background: isSettingsActive
+                  ? "var(--primary)"
+                  : "linear-gradient(135deg, var(--primary), var(--primary-hover))",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: "13px",
+                fontWeight: 700,
+                color: "#fff",
+                flexShrink: 0,
+                border: isSettingsActive
+                  ? "2px solid var(--primary-dark)"
+                  : "none",
+              }}
+            >
+              {getInitials(displayName, user.email)}
             </div>
+
             {!collapsed && (
-              <div style={{ overflow: "hidden" }}>
-                <div style={{ fontSize: "13px", fontWeight: 600, color: "var(--text-primary)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-                  {profile?.full_name || "Researcher"}
+              <div style={{ overflow: "hidden", flex: 1 }}>
+                <div
+                  style={{
+                    fontSize: "13px",
+                    fontWeight: 600,
+                    color: isSettingsActive
+                      ? "var(--primary-text)"
+                      : "var(--text-primary)",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  {displayName || "Researcher"}
                 </div>
-                <div style={{ fontSize: "11px", color: "var(--text-muted)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                <div
+                  style={{
+                    fontSize: "11px",
+                    color: "var(--text-muted)",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
                   {user.email}
                 </div>
               </div>
             )}
-          </div>
+
+            {!collapsed && (
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke={
+                  isSettingsActive ? "var(--primary)" : "var(--text-muted)"
+                }
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                style={{ flexShrink: 0, marginLeft: "auto" }}
+              >
+                <path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+            )}
+          </Link>
         </div>
       </aside>
 
-      {/* Main content */}
-      <div style={{
-        flex: 1, marginLeft: collapsed ? "72px" : "260px",
-        transition: "margin-left 250ms cubic-bezier(0.4, 0, 0.2, 1)",
-        display: "flex", flexDirection: "column", minHeight: "100vh",
-      }}>
-        {/* Top bar */}
-        <header style={{
-          display: "flex", alignItems: "center", justifyContent: "flex-end",
-          padding: "16px 32px", borderBottom: "1px solid var(--border)",
-          background: "var(--bg-surface)", gap: "16px", position: "sticky", top: 0, zIndex: 40,
-        }}>
-          <button 
-            className="btn btn-ghost" 
-            style={{ padding: "8px", borderRadius: "var(--radius-sm)", position: "relative" }}
+      <div
+        style={{
+          flex: 1,
+          marginLeft: collapsed ? "72px" : "260px",
+          transition: "margin-left 250ms cubic-bezier(0.4, 0, 0.2, 1)",
+          display: "flex",
+          flexDirection: "column",
+          minHeight: "100vh",
+        }}
+      >
+        <header
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "flex-end",
+            padding: "16px 32px",
+            borderBottom: "1px solid var(--border)",
+            background: "var(--bg-surface)",
+            gap: "16px",
+            position: "sticky",
+            top: 0,
+            zIndex: 40,
+          }}
+        >
+          <button
+            className="btn btn-ghost"
+            style={{ padding: "8px", borderRadius: "var(--radius-sm)" }}
             onClick={async () => {
               await supabase.auth.signOut();
               router.push("/auth/login");
             }}
             title="Sign Out"
           >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--text-secondary)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="var(--text-secondary)"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <path d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
             </svg>
           </button>
+
           <button
             className="btn btn-primary"
             style={{ padding: "8px 20px", fontSize: "13px" }}
             onClick={() => setIsCreateCampaignOpen(true)}
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <path d="M12 5v14M5 12h14" />
             </svg>
             New Campaign

--- a/frontend/app/dashboard/research/[id]/page.tsx
+++ b/frontend/app/dashboard/research/[id]/page.tsx
@@ -1,0 +1,578 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { supabase } from "@/lib/supabase";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+interface ResearchCampaign {
+  id: string;
+  user_id: string;
+  title: string;
+  description: string;
+  status: string;
+  campaign_id: string | null;
+  question_bank_mode: "text" | "file";
+  question_bank_text: string | null;
+  question_bank_file_name: string | null;
+  contact_list_file_name: string;
+  timeline_start: string;
+  timeline_end: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface Transcript {
+  id: string;
+  call_id: string;
+  sentiment: "positive" | "neutral" | "negative" | null;
+  excerpt: string | null;
+  full_text: string | null;
+  questions_count: number;
+  created_at: string;
+}
+
+interface Call {
+  id: string;
+  participant_name: string;
+  participant_phone: string | null;
+  status: string;
+  duration_seconds: number;
+  scheduled_for: string | null;
+  completed_at: string | null;
+  current_question_index: number;
+  created_at: string;
+  transcripts: Transcript[];
+}
+
+interface Contact {
+  id: string;
+  name: string;
+  phone: string | null;
+  email: string | null;
+  age: string | null;
+  occupation: string | null;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const fmt = {
+  duration(s: number | null) {
+    if (!s) return "—";
+    const m = Math.floor(s / 60);
+    const sec = s % 60;
+    return `${m}m ${sec.toString().padStart(2, "0")}s`;
+  },
+  date(d: string | null) {
+    if (!d) return "—";
+    return new Date(d).toLocaleDateString("en-US", {
+      month: "short", day: "numeric", year: "numeric",
+    });
+  },
+};
+
+// ── Badge ─────────────────────────────────────────────────────────────────────
+const BADGE_CLASS: Record<string, string> = {
+  completed:     "badge badge-success",
+  active:        "badge badge-success",
+  "in-progress": "badge badge-info",
+  pending:       "badge badge-warning",
+  ringing:       "badge badge-warning",
+  scheduled:     "badge badge-warning",
+  failed:        "badge badge-error",
+  missed:        "badge badge-error",
+  paused:        "badge badge-neutral",
+  draft:         "badge badge-neutral",
+  archived:      "badge badge-neutral",
+  positive:      "badge badge-success",
+  neutral:       "badge badge-warning",
+  negative:      "badge badge-error",
+};
+
+const BADGE_LABEL: Record<string, string> = {
+  "in-progress": "In Progress",
+};
+
+function Badge({ value }: { value: string | null }) {
+  const key = (value ?? "unknown").toLowerCase();
+  const cls = BADGE_CLASS[key] ?? "badge badge-neutral";
+  const label = BADGE_LABEL[key] ?? (value ? value.charAt(0).toUpperCase() + value.slice(1) : "—");
+  return <span className={cls}>{label}</span>;
+}
+
+// ── Stat Card ─────────────────────────────────────────────────────────────────
+function StatCard({ label, value, accent }: { label: string; value: string | number; accent?: string }) {
+  return (
+    <div className="card" style={{ padding: "18px 20px" }}>
+      <div
+        className="stat-value"
+        style={{ color: accent ?? "var(--primary)", fontVariantNumeric: "tabular-nums" }}
+      >
+        {value}
+      </div>
+      <div className="stat-label">{label}</div>
+    </div>
+  );
+}
+
+// ── Progress Ring ─────────────────────────────────────────────────────────────
+function ProgressRing({ pct }: { pct: number }) {
+  const r = 28, size = 72, circ = 2 * Math.PI * r;
+  const offset = circ * (1 - pct / 100);
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+      <circle cx={36} cy={36} r={r} fill="none" stroke="var(--bg-muted)" strokeWidth="6" />
+      <circle
+        cx={36} cy={36} r={r} fill="none"
+        stroke="var(--primary)" strokeWidth="6"
+        strokeDasharray={circ} strokeDashoffset={offset}
+        strokeLinecap="round" transform="rotate(-90 36 36)"
+        style={{ transition: "stroke-dashoffset 1s cubic-bezier(0.16,1,0.3,1)" }}
+      />
+      <text x="36" y="41" textAnchor="middle" fontSize="13" fontWeight="700" fill="var(--text-primary)">
+        {Math.round(pct)}%
+      </text>
+    </svg>
+  );
+}
+
+// ── Skeleton ──────────────────────────────────────────────────────────────────
+function Skeleton() {
+  return (
+    <div style={{ padding: "32px", display: "flex", flexDirection: "column", gap: "16px" }}>
+      {[60, 120, 80, 320].map((h, i) => (
+        <div key={i} className="skeleton" style={{ height: h, borderRadius: "var(--radius-lg)" }} />
+      ))}
+    </div>
+  );
+}
+
+// ── Sentiment Bar ─────────────────────────────────────────────────────────────
+function SentimentBar({ positive, neutral, negative, total }:
+  { positive: number; neutral: number; negative: number; total: number }) {
+  if (total === 0)
+    return <div style={{ height: 10, borderRadius: "var(--radius-full)", background: "var(--bg-muted)" }} />;
+
+  const pct = (n: number) => `${(n / total * 100).toFixed(1)}%`;
+  return (
+    <div>
+      <div style={{ display: "flex", height: 10, borderRadius: "var(--radius-full)", overflow: "hidden", gap: 2 }}>
+        <div style={{ width: pct(positive), background: "var(--success)" }} />
+        <div style={{ width: pct(neutral),  background: "var(--warning)" }} />
+        <div style={{ width: pct(negative), background: "var(--error)"   }} />
+      </div>
+      <div style={{ display: "flex", gap: 16, marginTop: 8 }} className="text-xs text-muted">
+        {([
+          ["var(--success)", "Positive", positive],
+          ["var(--warning)", "Neutral",  neutral ],
+          ["var(--error)",   "Negative", negative],
+        ] as [string, string, number][]).map(([c, l, n]) => (
+          <span key={l} style={{ display: "flex", alignItems: "center", gap: 5 }}>
+            <span style={{ width: 8, height: 8, borderRadius: "50%", background: c, display: "inline-block" }} />
+            {l} {n}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Avatar ────────────────────────────────────────────────────────────────────
+function Avatar({ name }: { name: string }) {
+  const initials = name.split(" ").map(n => n[0]).join("").slice(0, 2).toUpperCase();
+  return (
+    <div className="avatar avatar-sm">
+      {initials}
+    </div>
+  );
+}
+
+// ── Empty State ───────────────────────────────────────────────────────────────
+function EmptyState({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="card empty-state">
+      <p className="empty-state-title">{title}</p>
+      <p className="empty-state-body">{body}</p>
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+export default function ResearchDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const router  = useRouter();
+
+  const [research,       setResearch]       = useState<ResearchCampaign | null>(null);
+  const [calls,          setCalls]          = useState<Call[]>([]);
+  const [contacts,       setContacts]       = useState<Contact[]>([]);
+  const [loading,        setLoading]        = useState(true);
+  const [tab,            setTab]            = useState<"overview" | "calls" | "transcripts" | "contacts">("overview");
+  const [expandedCall,   setExpandedCall]   = useState<string | null>(null);
+  const [callFilter,     setCallFilter]     = useState("all");
+  const [updatingStatus, setUpdatingStatus] = useState(false);
+  const [notFound,       setNotFound]       = useState(false);
+
+  // ── Fetch ──────────────────────────────────────────────────────────────────
+  useEffect(() => {
+    const load = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) { router.push("/auth/login"); return; }
+
+      const { data: rc, error } = await supabase
+        .from("research_campaigns")
+        .select("*")
+        .eq("id", id)
+        .eq("user_id", session.user.id)
+        .single();
+
+      if (error || !rc) { setNotFound(true); setLoading(false); return; }
+      setResearch(rc);
+
+      if (rc.campaign_id) {
+        const { data: callsData } = await supabase
+          .from("calls")
+          .select("*, transcripts(id, sentiment, excerpt, full_text, questions_count, created_at)")
+          .eq("campaign_id", rc.campaign_id)
+          .order("created_at", { ascending: false });
+        setCalls(callsData ?? []);
+      }
+
+      const { data: contactsData } = await supabase
+        .from("contact_list")
+        .select("*")
+        .eq("research_campaign_id", id)
+        .order("created_at", { ascending: true });
+      setContacts(contactsData ?? []);
+
+      setLoading(false);
+    };
+    if (id) load();
+  }, [id, router]);
+
+  // ── Update status ──────────────────────────────────────────────────────────
+  const updateStatus = async (newStatus: string) => {
+    if (!research) return;
+    setUpdatingStatus(true);
+    const { data } = await supabase
+      .from("research_campaigns")
+      .update({ status: newStatus, updated_at: new Date().toISOString() })
+      .eq("id", research.id)
+      .select()
+      .single();
+    if (data) setResearch(data);
+    setUpdatingStatus(false);
+  };
+
+  if (loading)  return <Skeleton />;
+  if (notFound) return (
+    <div className="page-content">
+      <p className="text-muted" style={{ fontSize: 14 }}>Research campaign not found.</p>
+    </div>
+  );
+  if (!research) return null;
+
+  // ── Derived stats ──────────────────────────────────────────────────────────
+  const allTranscripts = calls.flatMap(c =>
+    c.transcripts.map(t => ({ ...t, participant_name: c.participant_name }))
+  );
+  const completed      = calls.filter(c => c.status === "completed").length;
+  const missed         = calls.filter(c => ["missed", "failed"].includes(c.status)).length;
+  const pending        = calls.filter(c => c.status === "pending").length;
+  const inProgress     = calls.filter(c => c.status === "in-progress").length;
+  const completionPct  = calls.length > 0 ? (completed / calls.length) * 100 : 0;
+  const sentPos        = allTranscripts.filter(t => t.sentiment === "positive").length;
+  const sentNeu        = allTranscripts.filter(t => t.sentiment === "neutral").length;
+  const sentNeg        = allTranscripts.filter(t => t.sentiment === "negative").length;
+  const filteredCalls  = callFilter === "all" ? calls : calls.filter(c => c.status === callFilter);
+  const daysLeft       = Math.max(0, Math.ceil(
+    (new Date(research.timeline_end).getTime() - Date.now()) / 86400000
+  ));
+
+  return (
+    <div className="animate-fade-in page-content">
+
+      {/* Back */}
+      <button
+        className="btn btn-ghost btn-sm"
+        onClick={() => router.back()}
+        style={{ alignSelf: "flex-start", display: "flex", alignItems: "center", gap: 6 }}
+      >
+        <svg width="15" height="15" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+          <path d="M19 12H5M12 5l-7 7 7 7" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+        All Campaigns
+      </button>
+
+      {/* Header card */}
+      <div className="card" style={{ padding: "24px 28px" }}>
+        <div className="flex-between" style={{ gap: 24, flexWrap: "wrap", alignItems: "flex-start" }}>
+          <div style={{ flex: 1 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 8 }}>
+              <h1 className="page-title" style={{ margin: 0 }}>{research.title}</h1>
+              <Badge value={research.status} />
+            </div>
+            <p className="text-secondary" style={{ marginBottom: 14, maxWidth: "65ch", lineHeight: 1.6 }}>
+              {research.description}
+            </p>
+            <div className="meta-row">
+              <span>📅 {fmt.date(research.timeline_start)} → {fmt.date(research.timeline_end)}</span>
+              {daysLeft > 0
+                ? <span className="text-primary" style={{ fontWeight: 500 }}>⏳ {daysLeft} days left</span>
+                : <span className="text-error" style={{ fontWeight: 500 }}>Timeline ended</span>
+              }
+              <span>🗂 {research.question_bank_mode === "text" ? "Typed questions" : research.question_bank_file_name}</span>
+              <span>👥 {contacts.length} contacts · {research.contact_list_file_name}</span>
+            </div>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 10 }}>
+            <ProgressRing pct={completionPct} />
+            <select
+              disabled={updatingStatus}
+              value={research.status}
+              onChange={e => updateStatus(e.target.value)}
+              className="select"
+              style={{ opacity: updatingStatus ? 0.6 : 1 }}
+            >
+              {["draft", "active", "paused", "completed", "archived"].map(s => (
+                <option key={s} value={s}>{s.charAt(0).toUpperCase() + s.slice(1)}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* Stat cards */}
+      <div className="stats-grid">
+        <StatCard label="Total Calls"     value={calls.length}          accent="var(--primary)"  />
+        <StatCard label="Completed"       value={completed}             accent="var(--success)"  />
+        <StatCard label="Missed / Failed" value={missed}                accent="var(--error)"    />
+        <StatCard label="Pending"         value={pending}               accent="var(--warning)"  />
+        <StatCard label="In Progress"     value={inProgress}            accent="var(--info)"     />
+        <StatCard label="Transcripts"     value={allTranscripts.length} accent="var(--primary)"  />
+      </div>
+
+      {/* Sentiment bar */}
+      {allTranscripts.length > 0 && (
+        <div className="card" style={{ padding: "20px 24px" }}>
+          <h3 className="section-title" style={{ marginBottom: 14 }}>
+            Sentiment — {allTranscripts.length} transcript{allTranscripts.length !== 1 ? "s" : ""}
+          </h3>
+          <SentimentBar positive={sentPos} neutral={sentNeu} negative={sentNeg} total={allTranscripts.length} />
+        </div>
+      )}
+
+      {/* Tabs */}
+      <div className="tab-bar">
+        {(["overview", "calls", "transcripts", "contacts"] as const).map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`tab-item ${tab === t ? "tab-item-active" : ""}`}
+          >
+            {t === "overview"    && "Overview"}
+            {t === "calls"       && `Calls (${calls.length})`}
+            {t === "transcripts" && `Transcripts (${allTranscripts.length})`}
+            {t === "contacts"    && `Contacts (${contacts.length})`}
+          </button>
+        ))}
+      </div>
+
+      {/* ── OVERVIEW ──────────────────────────────────────────────────── */}
+      {tab === "overview" && (
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 20 }}>
+
+          {/* Details */}
+          <div className="card" style={{ padding: "22px 24px" }}>
+            <h3 className="section-title" style={{ marginBottom: 16 }}>Details</h3>
+            <dl style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+              {([
+                ["Status",        <Badge key="s" value={research.status} />],
+                ["Start",         fmt.date(research.timeline_start)],
+                ["End",           fmt.date(research.timeline_end)],
+                ["Days left",     daysLeft > 0 ? `${daysLeft} days` : "Ended"],
+                ["Question Bank", research.question_bank_mode === "text" ? "Typed text" : research.question_bank_file_name ?? "—"],
+                ["Contact List",  `${contacts.length} contacts · ${research.contact_list_file_name}`],
+                ["Created",       fmt.date(research.created_at)],
+              ] as [string, React.ReactNode][]).map(([label, value]) => (
+                <div key={label as string} className="detail-row">
+                  <dt className="text-secondary">{label}</dt>
+                  <dd className="text-primary" style={{ fontWeight: 500, textAlign: "right" }}>{value}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+
+          {/* Question Bank */}
+          <div className="card" style={{ padding: "22px 24px" }}>
+            <h3 className="section-title" style={{ marginBottom: 16 }}>Question Bank</h3>
+            {research.question_bank_mode === "text" && research.question_bank_text ? (
+              <div className="text-secondary" style={{ fontSize: 13, lineHeight: 1.7, whiteSpace: "pre-wrap", maxHeight: 260, overflowY: "auto" }}>
+                {research.question_bank_text}
+              </div>
+            ) : research.question_bank_mode === "file" ? (
+              <div className="file-preview">
+                <svg width="20" height="20" fill="none" stroke="var(--primary)" strokeWidth="2" viewBox="0 0 24 24">
+                  <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" strokeLinecap="round" strokeLinejoin="round" />
+                  <polyline points="14,2 14,8 20,8" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+                <div>
+                  <div style={{ fontSize: 13, fontWeight: 500 }} className="text-primary">{research.question_bank_file_name}</div>
+                  <div className="text-muted" style={{ fontSize: 11, marginTop: 2 }}>PDF uploaded</div>
+                </div>
+              </div>
+            ) : (
+              <p className="text-muted" style={{ fontSize: 13 }}>No question bank set.</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* ── CALLS ─────────────────────────────────────────────────────── */}
+      {tab === "calls" && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          {/* Filter pills */}
+          <div className="filter-pills">
+            {["all", "pending", "in-progress", "completed", "missed", "failed"].map(f => {
+              const count = f === "all" ? calls.length : calls.filter(c => c.status === f).length;
+              return (
+                <button
+                  key={f}
+                  onClick={() => setCallFilter(f)}
+                  className={`filter-pill ${callFilter === f ? "filter-pill-active" : ""}`}
+                >
+                  {f === "all" ? "All" : f.replace("-", " ")} ({count})
+                </button>
+              );
+            })}
+          </div>
+
+          {filteredCalls.length === 0 ? (
+            <EmptyState title="No calls yet" body="Calls will appear once this research is active." />
+          ) : (
+            <div className="card table-card">
+              <table className="data-table">
+                <thead>
+                  <tr>
+                    {["Participant", "Status", "Scheduled", "Duration", "Transcripts", ""].map(h => (
+                      <th key={h}>{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredCalls.map(call => (
+                    <>
+                      <tr
+                        key={call.id}
+                        onClick={() => setExpandedCall(expandedCall === call.id ? null : call.id)}
+                        className={`table-row-interactive ${expandedCall === call.id ? "table-row-active" : ""}`}
+                      >
+                        <td>
+                          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                            <Avatar name={call.participant_name} />
+                            <div>
+                              <div className="participant-name">{call.participant_name}</div>
+                              <div className="participant-phone">{call.participant_phone ?? "—"}</div>
+                            </div>
+                          </div>
+                        </td>
+                        <td><Badge value={call.status} /></td>
+                        <td className="text-secondary">{fmt.date(call.scheduled_for)}</td>
+                        <td className="tabular-nums">{fmt.duration(call.duration_seconds)}</td>
+                        <td className="text-secondary">{call.transcripts.length}</td>
+                        <td className="text-muted">
+                          <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                            <path d={expandedCall === call.id ? "M5 15l7-7 7 7" : "M19 9l-7 7-7-7"} strokeLinecap="round" strokeLinejoin="round" />
+                          </svg>
+                        </td>
+                      </tr>
+                      {expandedCall === call.id && (
+                        <tr key={`${call.id}-exp`}>
+                          <td colSpan={6} className="expanded-row">
+                            {call.transcripts.length === 0 ? (
+                              <p className="text-muted" style={{ fontSize: 13, margin: 0 }}>No transcript for this call.</p>
+                            ) : call.transcripts.map(t => (
+                              <div key={t.id} style={{ marginBottom: 12 }}>
+                                <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
+                                  <Badge value={t.sentiment ?? "unknown"} />
+                                  <span className="text-muted" style={{ fontSize: 12 }}>{t.questions_count} questions answered</span>
+                                </div>
+                                {t.excerpt && (
+                                  <blockquote className="transcript-quote">&ldquo;{t.excerpt}&rdquo;</blockquote>
+                                )}
+                              </div>
+                            ))}
+                          </td>
+                        </tr>
+                      )}
+                    </>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── TRANSCRIPTS ───────────────────────────────────────────────── */}
+      {tab === "transcripts" && (
+        allTranscripts.length === 0 ? (
+          <EmptyState title="No transcripts yet" body="Transcripts appear after calls are completed." />
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {allTranscripts.map(t => (
+              <div key={t.id} className="card" style={{ padding: "18px 22px" }}>
+                <div className="flex-between" style={{ marginBottom: 10, flexWrap: "wrap", gap: 10 }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                    <Avatar name={t.participant_name} />
+                    <span className="participant-name">{t.participant_name}</span>
+                    <Badge value={t.sentiment ?? "unknown"} />
+                  </div>
+                  <span className="text-muted" style={{ fontSize: 12 }}>{fmt.date(t.created_at)}</span>
+                </div>
+                {t.excerpt && (
+                  <blockquote className="transcript-quote" style={{ marginBottom: 10 }}>&ldquo;{t.excerpt}&rdquo;</blockquote>
+                )}
+                <span className="text-muted" style={{ fontSize: 12 }}>{t.questions_count} questions answered</span>
+              </div>
+            ))}
+          </div>
+        )
+      )}
+
+      {/* ── CONTACTS ──────────────────────────────────────────────────── */}
+      {tab === "contacts" && (
+        contacts.length === 0 ? (
+          <EmptyState title="No contacts uploaded" body="Upload a contact list CSV when creating a campaign." />
+        ) : (
+          <div className="card table-card">
+            <table className="data-table">
+              <thead>
+                <tr>
+                  {["Name", "Phone", "Email", "Age", "Occupation"].map(h => (
+                    <th key={h}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {contacts.map(contact => (
+                  <tr key={contact.id} className="table-row-interactive">
+                    <td>
+                      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                        <Avatar name={contact.name} />
+                        <span className="participant-name">{contact.name}</span>
+                      </div>
+                    </td>
+                    <td className="text-secondary">{contact.phone ?? "—"}</td>
+                    <td className="text-secondary">{contact.email ?? "—"}</td>
+                    <td className="text-secondary">{contact.age ?? "—"}</td>
+                    <td className="text-secondary">{contact.occupation ?? "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )
+      )}
+
+    </div>
+  );
+}

--- a/frontend/app/dashboard/settings/page.tsx
+++ b/frontend/app/dashboard/settings/page.tsx
@@ -1,0 +1,773 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/lib/supabase";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+interface Profile {
+  id: string;
+  full_name: string;
+  role: "researcher" | "product" | "compliance";
+  company?: string | null;
+  timezone?: string | null;
+}
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function getInitials(name: string, email: string) {
+  if (name?.trim())
+    return name
+      .split(" ")
+      .map((n) => n[0])
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+  return email.slice(0, 2).toUpperCase();
+}
+
+// ── Save Button ───────────────────────────────────────────────────────────────
+function SaveButton({
+  state,
+  onClick,
+}: {
+  state: SaveState;
+  onClick: () => void;
+}) {
+  const map: Record<SaveState, { label: string; style: React.CSSProperties }> =
+    {
+      idle: { label: "Save Changes", style: {} },
+      saving: { label: "Saving…", style: { opacity: 0.7 } },
+      saved: {
+        label: "✓ Saved",
+        style: { background: "var(--success)", color: "#fff" },
+      },
+      error: {
+        label: "Retry",
+        style: {
+          background: "var(--danger-light)",
+          color: "#991B1B",
+          borderColor: "var(--danger)",
+        },
+      },
+    };
+  const s = map[state];
+  return (
+    <button
+      onClick={onClick}
+      disabled={state === "saving"}
+      className="btn btn-primary"
+      style={{ padding: "10px 22px", fontSize: 14, ...s.style }}
+    >
+      {s.label}
+    </button>
+  );
+}
+
+// ── Toggle ────────────────────────────────────────────────────────────────────
+function Toggle({
+  checked,
+  onChange,
+  id,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  id: string;
+}) {
+  return (
+    <button
+      id={id}
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      style={{
+        width: 44,
+        height: 24,
+        borderRadius: "var(--radius-full)",
+        background: checked ? "var(--primary)" : "var(--border)",
+        border: "none",
+        cursor: "pointer",
+        position: "relative",
+        flexShrink: 0,
+        transition: "background var(--transition-fast)",
+      }}
+    >
+      <span
+        style={{
+          position: "absolute",
+          top: 3,
+          left: checked ? 23 : 3,
+          width: 18,
+          height: 18,
+          borderRadius: "50%",
+          background: "#fff",
+          transition: "left var(--transition-fast)",
+          boxShadow: "0 1px 3px rgba(0,0,0,0.18)",
+        }}
+      />
+    </button>
+  );
+}
+
+// ── Section Card ──────────────────────────────────────────────────────────────
+function SectionCard({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="card" style={{ overflow: "hidden" }}>
+      <div
+        style={{
+          padding: "18px 24px",
+          borderBottom: "1px solid var(--border)",
+          background: "var(--bg-elevated)",
+        }}
+      >
+        <h2
+          style={{
+            fontSize: 15,
+            fontWeight: 600,
+            color: "var(--text-primary)",
+            margin: 0,
+          }}
+        >
+          {title}
+        </h2>
+        {description && (
+          <p
+            style={{
+              fontSize: 13,
+              color: "var(--text-muted)",
+              margin: "3px 0 0",
+            }}
+          >
+            {description}
+          </p>
+        )}
+      </div>
+      <div style={{ padding: "24px" }}>{children}</div>
+    </div>
+  );
+}
+
+// ── Field Row ─────────────────────────────────────────────────────────────────
+function Field({
+  label,
+  hint,
+  last,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  last?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "220px 1fr",
+        gap: "8px 24px",
+        alignItems: "start",
+        paddingBottom: last ? 0 : 20,
+        marginBottom: last ? 0 : 20,
+        borderBottom: last ? "none" : "1px solid var(--border-light)",
+      }}
+    >
+      <div style={{ paddingTop: 2 }}>
+        <p
+          style={{
+            fontSize: 14,
+            fontWeight: 500,
+            color: "var(--text-primary)",
+            margin: "0 0 2px",
+          }}
+        >
+          {label}
+        </p>
+        {hint && (
+          <p
+            style={{
+              fontSize: 12,
+              color: "var(--text-muted)",
+              margin: 0,
+              lineHeight: 1.5,
+            }}
+          >
+            {hint}
+          </p>
+        )}
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+// ── Skeleton ──────────────────────────────────────────────────────────────────
+function Skeleton() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      <style>{`@keyframes shimmer{0%{background-position:-200% 0}100%{background-position:200% 0}}`}</style>
+      {[80, 380, 260, 180, 120].map((h, i) => (
+        <div
+          key={i}
+          style={{
+            height: h,
+            borderRadius: "var(--radius-lg)",
+            background:
+              "linear-gradient(90deg,var(--bg-muted) 25%,var(--border) 50%,var(--bg-muted) 75%)",
+            backgroundSize: "200% 100%",
+            animation: "shimmer 1.5s ease-in-out infinite",
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+const ROLE_OPTIONS = [
+  { value: "researcher", label: "Researcher" },
+  { value: "product", label: "Product Manager" },
+  { value: "compliance", label: "Compliance Officer" },
+];
+
+const TIMEZONES = [
+  "Africa/Accra",
+  "Africa/Nairobi",
+  "Africa/Johannesburg",
+  "Africa/Lagos",
+  "Africa/Cairo",
+  "Africa/Casablanca",
+  "America/New_York",
+  "America/Chicago",
+  "America/Los_Angeles",
+  "Europe/London",
+  "Europe/Paris",
+  "Europe/Berlin",
+  "Asia/Dubai",
+  "Asia/Kolkata",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+  "Pacific/Auckland",
+];
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+export default function SettingsPage() {
+  const router = useRouter();
+
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  // Profile
+  const [fullName, setFullName] = useState("");
+  const [role, setRole] = useState<Profile["role"]>("researcher");
+  const [company, setCompany] = useState("");
+  const [timezone, setTimezone] = useState("Africa/Accra");
+  const [profileSave, setProfileSave] = useState<SaveState>("idle");
+
+  // Password
+  const [newPwd, setNewPwd] = useState("");
+  const [confirmPwd, setConfirmPwd] = useState("");
+  const [pwdSave, setPwdSave] = useState<SaveState>("idle");
+  const [pwdError, setPwdError] = useState("");
+
+  // Notifications
+  const [emailNotifs, setEmailNotifs] = useState(true);
+  const [callSummaries, setCallSummaries] = useState(true);
+  const [weeklyDigest, setWeeklyDigest] = useState(false);
+  const [prefSave, setPrefSave] = useState<SaveState>("idle");
+
+  // ── Fetch ──────────────────────────────────────────────────────────────────
+  useEffect(() => {
+    const load = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (!session) {
+        router.push("/auth/login");
+        return;
+      }
+
+      const user = session.user;
+      setEmail(user.email ?? "");
+
+      const { data: prof } = await supabase
+        .from("profiles")
+        .select("*")
+        .eq("id", user.id)
+        .single();
+
+      if (prof) {
+        setProfile(prof);
+        setFullName(prof.full_name ?? "");
+        setRole(prof.role ?? "researcher");
+        setCompany(prof.company ?? user.user_metadata?.company ?? "");
+        setTimezone(
+          prof.timezone ?? user.user_metadata?.timezone ?? "Africa/Accra"
+        );
+      }
+
+      const meta = user.user_metadata ?? {};
+      setEmailNotifs(meta.pref_email_notifs ?? true);
+      setCallSummaries(meta.pref_call_summaries ?? true);
+      setWeeklyDigest(meta.pref_weekly_digest ?? false);
+
+      setLoading(false);
+    };
+
+    load();
+  }, [router]);
+
+  // ── Save profile ───────────────────────────────────────────────────────────
+  const saveProfile = async () => {
+    if (!profile) return;
+    setProfileSave("saving");
+
+    const { error: dbErr } = await supabase
+      .from("profiles")
+      .update({
+        full_name: fullName,
+        role,
+        company: company || null,
+        timezone: timezone || null,
+      })
+      .eq("id", profile.id);
+
+    const { error: authErr } = await supabase.auth.updateUser({
+      data: { full_name: fullName, role, company, timezone },
+    });
+
+    if (dbErr && authErr) {
+      setProfileSave("error");
+      setTimeout(() => setProfileSave("idle"), 3000);
+    } else {
+      setProfile((p) =>
+        p ? { ...p, full_name: fullName, role, company, timezone } : p
+      );
+      setProfileSave("saved");
+      setTimeout(() => setProfileSave("idle"), 2500);
+    }
+  };
+
+  // ── Save password ──────────────────────────────────────────────────────────
+  const savePassword = async () => {
+    setPwdError("");
+
+    if (!newPwd) {
+      setPwdError("New password is required.");
+      return;
+    }
+
+    if (newPwd.length < 8) {
+      setPwdError("Password must be at least 8 characters.");
+      return;
+    }
+
+    if (newPwd !== confirmPwd) {
+      setPwdError("Passwords do not match.");
+      return;
+    }
+
+    setPwdSave("saving");
+    const { error } = await supabase.auth.updateUser({ password: newPwd });
+
+    if (error) {
+      setPwdError(error.message);
+      setPwdSave("error");
+      setTimeout(() => setPwdSave("idle"), 3000);
+    } else {
+      setNewPwd("");
+      setConfirmPwd("");
+      setPwdSave("saved");
+      setTimeout(() => setPwdSave("idle"), 2500);
+    }
+  };
+
+  // ── Save preferences ───────────────────────────────────────────────────────
+  const savePreferences = async () => {
+    setPrefSave("saving");
+
+    const { error } = await supabase.auth.updateUser({
+      data: {
+        pref_email_notifs: emailNotifs,
+        pref_call_summaries: callSummaries,
+        pref_weekly_digest: weeklyDigest,
+      },
+    });
+
+    if (error) {
+      setPrefSave("error");
+      setTimeout(() => setPrefSave("idle"), 3000);
+    } else {
+      setPrefSave("saved");
+      setTimeout(() => setPrefSave("idle"), 2500);
+    }
+  };
+
+  // ── Sign out ───────────────────────────────────────────────────────────────
+  const signOut = async () => {
+    await supabase.auth.signOut();
+    router.push("/auth/login");
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="animate-fade-in" style={{ padding: 8 }}>
+        <Skeleton />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="animate-fade-in"
+      style={{
+        maxWidth: 760,
+        display: "flex",
+        flexDirection: "column",
+        gap: 24,
+      }}
+    >
+      <div>
+        <h1
+          style={{
+            fontSize: 26,
+            fontWeight: 700,
+            color: "var(--text-primary)",
+            margin: "0 0 6px",
+          }}
+        >
+          Settings
+        </h1>
+        <p style={{ fontSize: 15, color: "var(--text-secondary)", margin: 0 }}>
+          Manage your account information and preferences
+        </p>
+      </div>
+
+      <SectionCard
+        title="Profile"
+        description="Update your personal information"
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 16,
+            paddingBottom: 24,
+            marginBottom: 24,
+            borderBottom: "1px solid var(--border-light)",
+          }}
+        >
+          <div
+            style={{
+              width: 60,
+              height: 60,
+              borderRadius: "50%",
+              background: "var(--primary-light)",
+              color: "var(--primary-text)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 20,
+              fontWeight: 700,
+              flexShrink: 0,
+              border: "2px solid var(--primary)",
+            }}
+          >
+            {getInitials(fullName, email)}
+          </div>
+          <div>
+            <p
+              style={{
+                fontSize: 16,
+                fontWeight: 600,
+                color: "var(--text-primary)",
+                margin: "0 0 2px",
+              }}
+            >
+              {fullName || "No name set"}
+            </p>
+            <p style={{ fontSize: 13, color: "var(--text-muted)", margin: 0 }}>
+              {email}
+            </p>
+            <span
+              className="badge badge-neutral"
+              style={{ marginTop: 6, fontSize: 11 }}
+            >
+              {ROLE_OPTIONS.find((r) => r.value === role)?.label ?? role}
+            </span>
+          </div>
+        </div>
+
+        <Field label="Full Name" hint="Your display name across the platform">
+          <input
+            className="input-base"
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+            placeholder="e.g. Nzu Sikhosana"
+          />
+        </Field>
+
+        <Field
+          label="Email Address"
+          hint="Contact support to change your email"
+        >
+          <input
+            className="input-base"
+            value={email}
+            disabled
+            style={{ cursor: "not-allowed", opacity: 0.6 }}
+          />
+        </Field>
+
+        <Field label="Role" hint="Your role determines your access level">
+          <select
+            className="input-base"
+            value={role}
+            onChange={(e) => setRole(e.target.value as Profile["role"])}
+            style={{ cursor: "pointer" }}
+          >
+            {ROLE_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <Field label="Company" hint="Optional — shown on your profile">
+          <input
+            className="input-base"
+            value={company}
+            onChange={(e) => setCompany(e.target.value)}
+            placeholder="e.g. Ashesi University"
+          />
+        </Field>
+
+        <Field
+          label="Timezone"
+          hint="Used to schedule calls at the right local time"
+          last
+        >
+          <select
+            className="input-base"
+            value={timezone}
+            onChange={(e) => setTimezone(e.target.value)}
+            style={{ cursor: "pointer" }}
+          >
+            {TIMEZONES.map((tz) => (
+              <option key={tz} value={tz}>
+                {tz.replace(/_/g, " ")}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            marginTop: 20,
+            paddingTop: 20,
+            borderTop: "1px solid var(--border-light)",
+          }}
+        >
+          <SaveButton state={profileSave} onClick={saveProfile} />
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Password" description="Update your account password">
+        <Field label="New Password" hint="Minimum 8 characters">
+          <input
+            className="input-base"
+            type="password"
+            value={newPwd}
+            onChange={(e) => setNewPwd(e.target.value)}
+            placeholder="Enter new password"
+          />
+        </Field>
+
+        <Field label="Confirm Password" last>
+          <input
+            className="input-base"
+            type="password"
+            value={confirmPwd}
+            onChange={(e) => setConfirmPwd(e.target.value)}
+            placeholder="Confirm new password"
+          />
+        </Field>
+
+        {pwdError && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              padding: "10px 14px",
+              marginTop: 12,
+              background: "var(--danger-light)",
+              border: "1px solid var(--danger)",
+              borderRadius: "var(--radius-sm)",
+              fontSize: 13,
+              color: "#991B1B",
+            }}
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <path d="M12 8v4m0 4h.01" />
+            </svg>
+            {pwdError}
+          </div>
+        )}
+
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            marginTop: 20,
+            paddingTop: 20,
+            borderTop: "1px solid var(--border-light)",
+          }}
+        >
+          <SaveButton state={pwdSave} onClick={savePassword} />
+        </div>
+      </SectionCard>
+
+      <SectionCard
+        title="Notifications"
+        description="Control when and how you receive updates"
+      >
+        {[
+          {
+            id: "notif-email",
+            label: "Email Notifications",
+            hint: "Receive email updates about your campaigns and calls",
+            value: emailNotifs,
+            set: setEmailNotifs,
+          },
+          {
+            id: "notif-calls",
+            label: "Call Summaries",
+            hint: "Get a summary email after each research call completes",
+            value: callSummaries,
+            set: setCallSummaries,
+          },
+          {
+            id: "notif-digest",
+            label: "Weekly Digest",
+            hint: "A weekly overview of campaign progress and insights",
+            value: weeklyDigest,
+            set: setWeeklyDigest,
+          },
+        ].map(({ id, label, hint, value, set }, i, arr) => (
+          <div
+            key={id}
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              paddingBottom: i < arr.length - 1 ? 20 : 0,
+              marginBottom: i < arr.length - 1 ? 20 : 0,
+              borderBottom:
+                i < arr.length - 1 ? "1px solid var(--border-light)" : "none",
+            }}
+          >
+            <label htmlFor={id} style={{ cursor: "pointer", flex: 1 }}>
+              <p
+                style={{
+                  fontSize: 14,
+                  fontWeight: 500,
+                  color: "var(--text-primary)",
+                  margin: "0 0 2px",
+                }}
+              >
+                {label}
+              </p>
+              <p
+                style={{ fontSize: 12, color: "var(--text-muted)", margin: 0 }}
+              >
+                {hint}
+              </p>
+            </label>
+            <Toggle id={id} checked={value} onChange={set} />
+          </div>
+        ))}
+
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            marginTop: 20,
+            paddingTop: 20,
+            borderTop: "1px solid var(--border-light)",
+          }}
+        >
+          <SaveButton state={prefSave} onClick={savePreferences} />
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Account">
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <div>
+            <p
+              style={{
+                fontSize: 14,
+                fontWeight: 500,
+                color: "var(--text-primary)",
+                margin: "0 0 2px",
+              }}
+            >
+              Sign Out
+            </p>
+            <p style={{ fontSize: 12, color: "var(--text-muted)", margin: 0 }}>
+              Sign out of your Echo account on this device
+            </p>
+          </div>
+          <button
+            onClick={signOut}
+            className="btn btn-secondary"
+            style={{ padding: "9px 20px", fontSize: 14 }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = "var(--danger-light)";
+              e.currentTarget.style.color = "#991B1B";
+              e.currentTarget.style.borderColor = "var(--danger)";
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = "";
+              e.currentTarget.style.color = "";
+              e.currentTarget.style.borderColor = "";
+            }}
+          >
+            Sign Out
+          </button>
+        </div>
+      </SectionCard>
+    </div>
+  );
+}

--- a/frontend/app/dashboard/transcripts/page.tsx
+++ b/frontend/app/dashboard/transcripts/page.tsx
@@ -11,7 +11,8 @@ const transcripts = [
     duration: "14:23",
     questions: 8,
     sentiment: "positive",
-    excerpt: "I really enjoyed the step-by-step walkthrough. It made the whole process feel intuitive and I didn't need to look for help at any point...",
+    excerpt:
+      "I really enjoyed the step-by-step walkthrough. It made the whole process feel intuitive and I didn't need to look for help at any point...",
   },
   {
     id: "t2",
@@ -21,7 +22,8 @@ const transcripts = [
     duration: "11:05",
     questions: 8,
     sentiment: "neutral",
-    excerpt: "The sign-up was straightforward, but I wasn't sure what to do after creating my account. The dashboard felt a bit overwhelming at first...",
+    excerpt:
+      "The sign-up was straightforward, but I wasn't sure what to do after creating my account. The dashboard felt a bit overwhelming at first...",
   },
   {
     id: "t3",
@@ -31,7 +33,8 @@ const transcripts = [
     duration: "16:50",
     questions: 12,
     sentiment: "positive",
-    excerpt: "Your support team has been amazing. Every time I reach out, I get a response within an hour and they always resolve my issues quickly...",
+    excerpt:
+      "Your support team has been amazing. Every time I reach out, I get a response within an hour and they always resolve my issues quickly...",
   },
   {
     id: "t4",
@@ -41,7 +44,8 @@ const transcripts = [
     duration: "12:34",
     questions: 8,
     sentiment: "negative",
-    excerpt: "I had trouble connecting my external accounts. The integration page kept failing silently without any error messages, which was frustrating...",
+    excerpt:
+      "I had trouble connecting my external accounts. The integration page kept failing silently without any error messages, which was frustrating...",
   },
   {
     id: "t5",
@@ -51,7 +55,8 @@ const transcripts = [
     duration: "9:22",
     questions: 12,
     sentiment: "positive",
-    excerpt: "The new analytics dashboard is exactly what we needed. Being able to see real-time metrics has significantly improved our decision-making...",
+    excerpt:
+      "The new analytics dashboard is exactly what we needed. Being able to see real-time metrics has significantly improved our decision-making...",
   },
   {
     id: "t6",
@@ -61,11 +66,15 @@ const transcripts = [
     duration: "15:01",
     questions: 6,
     sentiment: "neutral",
-    excerpt: "I think the collaboration features should be the top priority. We use the product mainly for team projects and better sharing would help a lot...",
+    excerpt:
+      "I think the collaboration features should be the top priority. We use the product mainly for team projects and better sharing would help a lot...",
   },
 ];
 
-const sentimentConfig: Record<string, { label: string; color: string; bg: string }> = {
+const sentimentConfig: Record<
+  string,
+  { label: string; color: string; bg: string }
+> = {
   positive: { label: "Positive", color: "#065F46", bg: "var(--success-light)" },
   neutral: { label: "Neutral", color: "#92400E", bg: "var(--warning-light)" },
   negative: { label: "Negative", color: "#991B1B", bg: "var(--danger-light)" },
@@ -82,7 +91,8 @@ export default function TranscriptsPage() {
       search === "" ||
       t.participant.toLowerCase().includes(search.toLowerCase()) ||
       t.excerpt.toLowerCase().includes(search.toLowerCase());
-    const matchesCampaign = campaignFilter === "all" || t.campaign === campaignFilter;
+    const matchesCampaign =
+      campaignFilter === "all" || t.campaign === campaignFilter;
     return matchesSearch && matchesCampaign;
   });
 
@@ -98,15 +108,34 @@ export default function TranscriptsPage() {
         }}
       >
         <div>
-          <h1 style={{ fontSize: "26px", fontWeight: 700, color: "var(--text-primary)", marginBottom: "6px" }}>
+          <h1
+            style={{
+              fontSize: "26px",
+              fontWeight: 700,
+              color: "var(--text-primary)",
+              marginBottom: "6px",
+            }}
+          >
             Transcripts
           </h1>
           <p style={{ fontSize: "15px", color: "var(--text-secondary)" }}>
             Browse, search, and export completed interview transcripts
           </p>
         </div>
-        <button className="btn btn-secondary" style={{ padding: "10px 20px", fontSize: "14px" }}>
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <button
+          className="btn btn-secondary"
+          style={{ padding: "10px 20px", fontSize: "14px" }}
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
             <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" />
           </svg>
           Export All
@@ -125,7 +154,12 @@ export default function TranscriptsPage() {
             strokeWidth="1.8"
             strokeLinecap="round"
             strokeLinejoin="round"
-            style={{ position: "absolute", left: "14px", top: "50%", transform: "translateY(-50%)" }}
+            style={{
+              position: "absolute",
+              left: "14px",
+              top: "50%",
+              transform: "translateY(-50%)",
+            }}
           >
             <circle cx="11" cy="11" r="8" />
             <line x1="21" y1="21" x2="16.65" y2="16.65" />
@@ -147,18 +181,29 @@ export default function TranscriptsPage() {
         >
           <option value="all">All Campaigns</option>
           {campaigns.map((c) => (
-            <option key={c} value={c}>{c}</option>
+            <option key={c} value={c}>
+              {c}
+            </option>
           ))}
         </select>
       </div>
 
       {/* Results count */}
-      <div style={{ fontSize: "13px", color: "var(--text-muted)", marginBottom: "16px" }}>
+      <div
+        style={{
+          fontSize: "13px",
+          color: "var(--text-muted)",
+          marginBottom: "16px",
+        }}
+      >
         Showing {filtered.length} of {transcripts.length} transcripts
       </div>
 
       {/* Transcript list */}
-      <div className="stagger-children" style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+      <div
+        className="stagger-children"
+        style={{ display: "flex", flexDirection: "column", gap: "12px" }}
+      >
         {filtered.map((transcript) => (
           <div
             key={transcript.id}
@@ -182,7 +227,10 @@ export default function TranscriptsPage() {
                   flexShrink: 0,
                 }}
               >
-                {transcript.participant.split(" ").map((n) => n[0]).join("")}
+                {transcript.participant
+                  .split(" ")
+                  .map((n) => n[0])
+                  .join("")}
               </div>
 
               {/* Content */}
@@ -195,7 +243,13 @@ export default function TranscriptsPage() {
                     marginBottom: "6px",
                   }}
                 >
-                  <span style={{ fontSize: "15px", fontWeight: 600, color: "var(--text-primary)" }}>
+                  <span
+                    style={{
+                      fontSize: "15px",
+                      fontWeight: 600,
+                      color: "var(--text-primary)",
+                    }}
+                  >
                     {transcript.participant}
                   </span>
                   <span
@@ -211,10 +265,23 @@ export default function TranscriptsPage() {
                     {sentimentConfig[transcript.sentiment].label}
                   </span>
                 </div>
-                <div style={{ fontSize: "13px", color: "var(--text-muted)", marginBottom: "10px" }}>
+                <div
+                  style={{
+                    fontSize: "13px",
+                    color: "var(--text-muted)",
+                    marginBottom: "10px",
+                  }}
+                >
                   {transcript.campaign}
                 </div>
-                <p style={{ fontSize: "14px", color: "var(--text-secondary)", lineHeight: 1.6, margin: 0 }}>
+                <p
+                  style={{
+                    fontSize: "14px",
+                    color: "var(--text-secondary)",
+                    lineHeight: 1.6,
+                    margin: 0,
+                  }}
+                >
                   &ldquo;{transcript.excerpt}&rdquo;
                 </p>
               </div>
@@ -229,16 +296,52 @@ export default function TranscriptsPage() {
                   flexShrink: 0,
                 }}
               >
-                <div style={{ fontSize: "13px", color: "var(--text-muted)" }}>{transcript.date}</div>
-                <div style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "13px", color: "var(--text-secondary)" }}>
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <div style={{ fontSize: "13px", color: "var(--text-muted)" }}>
+                  {transcript.date}
+                </div>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "4px",
+                    fontSize: "13px",
+                    color: "var(--text-secondary)",
+                  }}
+                >
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
                     <circle cx="12" cy="12" r="10" />
                     <polyline points="12,6 12,12 16,14" />
                   </svg>
                   {transcript.duration}
                 </div>
-                <div style={{ display: "flex", alignItems: "center", gap: "4px", fontSize: "13px", color: "var(--text-secondary)" }}>
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "4px",
+                    fontSize: "13px",
+                    color: "var(--text-secondary)",
+                  }}
+                >
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
                     <path d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                   {transcript.questions}q

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2,55 +2,55 @@
 
 :root {
   /* Background — clean, very subtle cool-warm white */
-  --bg-base: #F8FAF9;
-  --bg-surface: #FFFFFF;
-  --bg-elevated: #F1F5F3;
-  --bg-muted: #E8EDEA;
-  --bg-input: #F3F5F4;
+  --bg-base: #f8faf9;
+  --bg-surface: #ffffff;
+  --bg-elevated: #f1f5f3;
+  --bg-muted: #e8edea;
+  --bg-input: #f3f5f4;
 
   /* Sidebar */
-  --sidebar-bg: #FFFFFF;
-  --sidebar-hover: #F1F5F3;
-  --sidebar-active: #ECFDF5;
-  --sidebar-text: #6B7280;
+  --sidebar-bg: #ffffff;
+  --sidebar-hover: #f1f5f3;
+  --sidebar-active: #ecfdf5;
+  --sidebar-text: #6b7280;
   --sidebar-text-active: #111827;
-  --sidebar-accent: #2DD4A0;
-  --sidebar-border: #E8EDEA;
+  --sidebar-accent: #2dd4a0;
+  --sidebar-border: #e8edea;
 
   /* Primary — teal / mint green (like the reference) */
-  --primary: #2DD4A0;
-  --primary-hover: #0EB883;
-  --primary-dark: #0D9668;
-  --primary-light: #ECFDF5;
-  --primary-subtle: #F0FDF9;
-  --primary-text: #065F46;
+  --primary: #2dd4a0;
+  --primary-hover: #0eb883;
+  --primary-dark: #0d9668;
+  --primary-light: #ecfdf5;
+  --primary-subtle: #f0fdf9;
+  --primary-text: #065f46;
 
   /* Secondary accents */
-  --accent-blue: #60A5FA;
-  --accent-blue-light: #EFF6FF;
-  --accent-amber: #FBBF24;
-  --accent-amber-light: #FFFBEB;
+  --accent-blue: #60a5fa;
+  --accent-blue-light: #eff6ff;
+  --accent-amber: #fbbf24;
+  --accent-amber-light: #fffbeb;
 
   /* Semantic */
-  --success: #34D399;
-  --success-light: #ECFDF5;
-  --warning: #FBBF24;
-  --warning-light: #FFFBEB;
-  --danger: #F87171;
-  --danger-light: #FEF2F2;
-  --info: #60A5FA;
-  --info-light: #EFF6FF;
+  --success: #34d399;
+  --success-light: #ecfdf5;
+  --warning: #fbbf24;
+  --warning-light: #fffbeb;
+  --danger: #f87171;
+  --danger-light: #fef2f2;
+  --info: #60a5fa;
+  --info-light: #eff6ff;
 
   /* Text */
   --text-primary: #111827;
-  --text-secondary: #4B5563;
-  --text-muted: #9CA3AF;
-  --text-inverse: #FFFFFF;
+  --text-secondary: #4b5563;
+  --text-muted: #9ca3af;
+  --text-inverse: #ffffff;
 
   /* Borders */
-  --border: #E5E7EB;
-  --border-light: #F3F4F6;
-  --border-focus: #2DD4A0;
+  --border: #e5e7eb;
+  --border-light: #f3f4f6;
+  --border-focus: #2dd4a0;
 
   /* Shadows */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
@@ -86,7 +86,9 @@
   --font-sans: "Inter", system-ui, -apple-system, sans-serif;
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
 
 body {
   background: var(--bg-base);
@@ -97,49 +99,115 @@ body {
 }
 
 /* Scrollbar */
-::-webkit-scrollbar { width: 6px; height: 6px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--border); border-radius: var(--radius-full); }
-::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: var(--radius-full);
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
 
 /* Animations */
 @keyframes fadeIn {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 @keyframes slideInLeft {
-  from { opacity: 0; transform: translateX(-12px); }
-  to { opacity: 1; transform: translateX(0); }
+  from {
+    opacity: 0;
+    transform: translateX(-12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 @keyframes slideInRight {
-  from { opacity: 0; transform: translateX(12px); }
-  to { opacity: 1; transform: translateX(0); }
+  from {
+    opacity: 0;
+    transform: translateX(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 @keyframes scaleIn {
-  from { opacity: 0; transform: scale(0.95); }
-  to { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 @keyframes pulse-soft {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
 }
 @keyframes waveBar {
-  0%, 100% { transform: scaleY(0.4); }
-  50% { transform: scaleY(1); }
+  0%,
+  100% {
+    transform: scaleY(0.4);
+  }
+  50% {
+    transform: scaleY(1);
+  }
 }
 
-.animate-fade-in { animation: fadeIn 0.5s cubic-bezier(0.4, 0, 0.2, 1) both; }
-.animate-slide-in-left { animation: slideInLeft 0.4s cubic-bezier(0.4, 0, 0.2, 1) both; }
-.animate-slide-in-right { animation: slideInRight 0.4s cubic-bezier(0.4, 0, 0.2, 1) both; }
-.animate-scale-in { animation: scaleIn 0.3s cubic-bezier(0.4, 0, 0.2, 1) both; }
+.animate-fade-in {
+  animation: fadeIn 0.5s cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+.animate-slide-in-left {
+  animation: slideInLeft 0.4s cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+.animate-slide-in-right {
+  animation: slideInRight 0.4s cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+.animate-scale-in {
+  animation: scaleIn 0.3s cubic-bezier(0.4, 0, 0.2, 1) both;
+}
 
-.stagger-children > * { animation: fadeIn 0.4s cubic-bezier(0.4, 0, 0.2, 1) both; }
-.stagger-children > *:nth-child(1) { animation-delay: 0ms; }
-.stagger-children > *:nth-child(2) { animation-delay: 60ms; }
-.stagger-children > *:nth-child(3) { animation-delay: 120ms; }
-.stagger-children > *:nth-child(4) { animation-delay: 180ms; }
-.stagger-children > *:nth-child(5) { animation-delay: 240ms; }
-.stagger-children > *:nth-child(6) { animation-delay: 300ms; }
+.stagger-children > * {
+  animation: fadeIn 0.4s cubic-bezier(0.4, 0, 0.2, 1) both;
+}
+.stagger-children > *:nth-child(1) {
+  animation-delay: 0ms;
+}
+.stagger-children > *:nth-child(2) {
+  animation-delay: 60ms;
+}
+.stagger-children > *:nth-child(3) {
+  animation-delay: 120ms;
+}
+.stagger-children > *:nth-child(4) {
+  animation-delay: 180ms;
+}
+.stagger-children > *:nth-child(5) {
+  animation-delay: 240ms;
+}
+.stagger-children > *:nth-child(6) {
+  animation-delay: 300ms;
+}
 
 /* Sound wave logo */
 .soundwave {
@@ -155,24 +223,66 @@ body {
   background: var(--primary);
   animation: waveBar 1.2s ease-in-out infinite;
 }
-.soundwave-bar:nth-child(1) { height: 20px; animation-delay: 0s; }
-.soundwave-bar:nth-child(2) { height: 32px; animation-delay: 0.15s; }
-.soundwave-bar:nth-child(3) { height: 44px; animation-delay: 0.3s; }
-.soundwave-bar:nth-child(4) { height: 36px; animation-delay: 0.45s; }
-.soundwave-bar:nth-child(5) { height: 28px; animation-delay: 0.6s; }
-.soundwave-bar:nth-child(6) { height: 40px; animation-delay: 0.75s; }
-.soundwave-bar:nth-child(7) { height: 24px; animation-delay: 0.9s; }
+.soundwave-bar:nth-child(1) {
+  height: 20px;
+  animation-delay: 0s;
+}
+.soundwave-bar:nth-child(2) {
+  height: 32px;
+  animation-delay: 0.15s;
+}
+.soundwave-bar:nth-child(3) {
+  height: 44px;
+  animation-delay: 0.3s;
+}
+.soundwave-bar:nth-child(4) {
+  height: 36px;
+  animation-delay: 0.45s;
+}
+.soundwave-bar:nth-child(5) {
+  height: 28px;
+  animation-delay: 0.6s;
+}
+.soundwave-bar:nth-child(6) {
+  height: 40px;
+  animation-delay: 0.75s;
+}
+.soundwave-bar:nth-child(7) {
+  height: 24px;
+  animation-delay: 0.9s;
+}
 
-.soundwave-static .soundwave-bar { animation: none; }
-.soundwave-sm { height: 24px; gap: 2px; }
-.soundwave-sm .soundwave-bar { width: 3px; }
-.soundwave-sm .soundwave-bar:nth-child(1) { height: 10px; }
-.soundwave-sm .soundwave-bar:nth-child(2) { height: 16px; }
-.soundwave-sm .soundwave-bar:nth-child(3) { height: 22px; }
-.soundwave-sm .soundwave-bar:nth-child(4) { height: 18px; }
-.soundwave-sm .soundwave-bar:nth-child(5) { height: 14px; }
-.soundwave-sm .soundwave-bar:nth-child(6) { height: 20px; }
-.soundwave-sm .soundwave-bar:nth-child(7) { height: 12px; }
+.soundwave-static .soundwave-bar {
+  animation: none;
+}
+.soundwave-sm {
+  height: 24px;
+  gap: 2px;
+}
+.soundwave-sm .soundwave-bar {
+  width: 3px;
+}
+.soundwave-sm .soundwave-bar:nth-child(1) {
+  height: 10px;
+}
+.soundwave-sm .soundwave-bar:nth-child(2) {
+  height: 16px;
+}
+.soundwave-sm .soundwave-bar:nth-child(3) {
+  height: 22px;
+}
+.soundwave-sm .soundwave-bar:nth-child(4) {
+  height: 18px;
+}
+.soundwave-sm .soundwave-bar:nth-child(5) {
+  height: 14px;
+}
+.soundwave-sm .soundwave-bar:nth-child(6) {
+  height: 20px;
+}
+.soundwave-sm .soundwave-bar:nth-child(7) {
+  height: 12px;
+}
 
 /* Form elements */
 .form-label {
@@ -194,12 +304,22 @@ body {
   color: var(--text-primary);
   font-size: 15px;
   font-family: inherit;
-  transition: border-color var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast);
+  transition: border-color var(--transition-fast),
+    box-shadow var(--transition-fast), background var(--transition-fast);
   outline: none;
 }
-.input-base::placeholder { color: var(--text-muted); }
-.input-base:hover { border-color: var(--text-muted); background: var(--bg-surface); }
-.input-base:focus { border-color: var(--primary); box-shadow: var(--shadow-focus); background: var(--bg-surface); }
+.input-base::placeholder {
+  color: var(--text-muted);
+}
+.input-base:hover {
+  border-color: var(--text-muted);
+  background: var(--bg-surface);
+}
+.input-base:focus {
+  border-color: var(--primary);
+  box-shadow: var(--shadow-focus);
+  background: var(--bg-surface);
+}
 
 /* Buttons */
 .btn {
@@ -218,8 +338,13 @@ body {
   outline: none;
   text-decoration: none;
 }
-.btn:focus-visible { box-shadow: var(--shadow-focus); }
-.btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.btn:focus-visible {
+  box-shadow: var(--shadow-focus);
+}
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
 
 .btn-primary {
   background: var(--primary);
@@ -230,20 +355,28 @@ body {
   transform: translateY(-1px);
   box-shadow: var(--shadow-md);
 }
-.btn-primary:active:not(:disabled) { transform: translateY(0); }
+.btn-primary:active:not(:disabled) {
+  transform: translateY(0);
+}
 
 .btn-secondary {
   background: var(--bg-surface);
   color: var(--text-primary);
   border: 1.5px solid var(--border);
 }
-.btn-secondary:hover:not(:disabled) { background: var(--bg-elevated); border-color: var(--text-muted); }
+.btn-secondary:hover:not(:disabled) {
+  background: var(--bg-elevated);
+  border-color: var(--text-muted);
+}
 
 .btn-ghost {
   background: transparent;
   color: var(--text-secondary);
 }
-.btn-ghost:hover:not(:disabled) { background: var(--bg-elevated); color: var(--text-primary); }
+.btn-ghost:hover:not(:disabled) {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
 
 /* Cards */
 .card {
@@ -251,7 +384,8 @@ body {
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
-  transition: box-shadow var(--transition-base), transform var(--transition-base);
+  transition: box-shadow var(--transition-base),
+    transform var(--transition-base);
 }
 .card-interactive:hover {
   box-shadow: var(--shadow-md);
@@ -269,17 +403,44 @@ body {
   font-weight: 500;
   line-height: 1.4;
 }
-.badge-success { background: var(--success-light); color: #065F46; }
-.badge-warning { background: var(--warning-light); color: #92400E; }
-.badge-danger { background: var(--danger-light); color: #991B1B; }
-.badge-info { background: var(--info-light); color: #1E40AF; }
-.badge-neutral { background: var(--bg-muted); color: var(--text-secondary); }
+.badge-success {
+  background: var(--success-light);
+  color: #065f46;
+}
+.badge-warning {
+  background: var(--warning-light);
+  color: #92400e;
+}
+.badge-danger {
+  background: var(--danger-light);
+  color: #991b1b;
+}
+.badge-info {
+  background: var(--info-light);
+  color: #1e40af;
+}
+.badge-neutral {
+  background: var(--bg-muted);
+  color: var(--text-secondary);
+}
 
 /* Status dots */
-.status-dot { width: 8px; height: 8px; border-radius: var(--radius-full); flex-shrink: 0; }
-.status-dot-active { background: var(--success); animation: pulse-soft 2s infinite; }
-.status-dot-pending { background: var(--warning); }
-.status-dot-failed { background: var(--danger); }
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+.status-dot-active {
+  background: var(--success);
+  animation: pulse-soft 2s infinite;
+}
+.status-dot-pending {
+  background: var(--warning);
+}
+.status-dot-failed {
+  background: var(--danger);
+}
 
 /* Divider with text */
 .divider-text {
@@ -300,4 +461,252 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-muted);
+}
+/* ── Layout helpers ─────────────────────────────── */
+.page-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 32px;
+  max-width: 1100px;
+}
+.flex-between {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.meta-row {
+  display: flex;
+  gap: 20px;
+  font-size: 12px;
+  color: var(--text-muted);
+  flex-wrap: wrap;
+}
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 12px;
+}
+
+/* Typography helpers   */
+.page-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.section-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+.stat-value {
+  font-size: 26px;
+  font-weight: 700;
+}
+.stat-label {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.text-primary {
+  color: var(--text-primary);
+}
+.text-secondary {
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+.text-muted {
+  color: var(--text-muted);
+}
+.text-error {
+  color: var(--error);
+}
+.text-xs {
+  font-size: 12px;
+}
+.tabular-nums {
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+/* Tabs  */
+.tab-bar {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--border);
+}
+.tab-item {
+  padding: 10px 20px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-secondary);
+  font-weight: 400;
+  font-size: 14px;
+  cursor: pointer;
+  margin-bottom: -1px;
+  transition: all 150ms ease;
+  text-transform: capitalize;
+  font-family: inherit;
+}
+.tab-item-active {
+  border-bottom-color: var(--primary);
+  color: var(--primary);
+  font-weight: 600;
+}
+
+/* Filter pills */
+.filter-pills {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.filter-pill {
+  padding: 6px 14px;
+  border-radius: var(--radius-full);
+  font-size: 12px;
+  font-weight: 500;
+  border: 1.5px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 150ms ease;
+}
+.filter-pill-active {
+  border-color: var(--primary);
+  background: var(--primary-subtle);
+  color: var(--primary);
+}
+
+/* Tables  */
+.table-card {
+  overflow: hidden;
+  padding: 0;
+}
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.data-table thead tr {
+  background: var(--bg-muted);
+  border-bottom: 1px solid var(--border);
+}
+.data-table th {
+  padding: 11px 16px;
+  text-align: left;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.data-table td {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.table-row-interactive {
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+.table-row-interactive:hover {
+  background: var(--bg-muted);
+}
+.table-row-active {
+  background: var(--bg-muted);
+}
+.expanded-row {
+  background: var(--bg-muted);
+  padding: 14px 20px 18px 56px;
+}
+
+/*  Participants */
+.participant-name {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text-primary);
+}
+.participant-phone {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+/* Avatar  */
+.avatar {
+  border-radius: 50%;
+  background: var(--primary-subtle);
+  color: var(--primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.avatar-sm {
+  width: 34px;
+  height: 34px;
+  font-size: 12px;
+}
+
+/*   Detail rows (overview tab)  */
+.detail-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 13px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 10px;
+}
+
+/*   File preview  */
+.file-preview {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px;
+  background: var(--bg-muted);
+  border-radius: var(--radius-md);
+}
+
+/*   Transcript quote   */
+.transcript-quote {
+  margin: 0;
+  padding: 10px 14px;
+  border-left: 3px solid var(--border);
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  font-style: italic;
+}
+
+/*  Empty state   */
+.empty-state {
+  padding: 56px;
+  text-align: center;
+}
+.empty-state-title {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin: 0 0 4px;
+}
+.empty-state-body {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+/*   Select input   */
+.select {
+  padding: 6px 10px;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-family: inherit;
+  transition: opacity 150ms ease;
 }

--- a/frontend/app/new_compaign/create_compaign/ResearchCampaignModal.tsx
+++ b/frontend/app/new_compaign/create_compaign/ResearchCampaignModal.tsx
@@ -22,11 +22,18 @@ function sanitizeFileName(fileName: string) {
   return fileName.replace(/[^a-zA-Z0-9._-]/g, "_");
 }
 
-export default function ResearchCampaignModal({ isOpen, onClose }: ResearchCampaignModalProps) {
-  const [questionBankMode, setQuestionBankMode] = useState<"text" | "file">("text");
+export default function ResearchCampaignModal({
+  isOpen,
+  onClose,
+}: ResearchCampaignModalProps) {
+  const [questionBankMode, setQuestionBankMode] = useState<"text" | "file">(
+    "text"
+  );
   const [title, setTitle] = useState(initialState.title);
   const [description, setDescription] = useState(initialState.description);
-  const [questionBankText, setQuestionBankText] = useState(initialState.questionBankText);
+  const [questionBankText, setQuestionBankText] = useState(
+    initialState.questionBankText
+  );
   const [startAt, setStartAt] = useState(initialState.startAt);
   const [endAt, setEndAt] = useState(initialState.endAt);
   const [questionBankFile, setQuestionBankFile] = useState<File | null>(null);
@@ -89,43 +96,63 @@ export default function ResearchCampaignModal({ isOpen, onClose }: ResearchCampa
 
       let questionBankFilePath: string | null = null;
       if (questionBankMode === "file" && questionBankFile) {
-        questionBankFilePath = `${userId}/question-bank/${timePrefix}-${sanitizeFileName(questionBankFile.name)}`;
+        questionBankFilePath = `${userId}/question-bank/${timePrefix}-${sanitizeFileName(
+          questionBankFile.name
+        )}`;
         const { error: uploadQuestionBankError } = await supabase.storage
           .from(RESEARCH_ASSETS_BUCKET)
           .upload(questionBankFilePath, questionBankFile, { upsert: false });
 
         if (uploadQuestionBankError) {
-          throw new Error(`Failed to upload question bank PDF: ${uploadQuestionBankError.message}`);
+          throw new Error(
+            `Failed to upload question bank PDF: ${uploadQuestionBankError.message}`
+          );
         }
       }
 
-      const contactListFilePath = `${userId}/contact-list/${timePrefix}-${sanitizeFileName(contactListFile.name)}`;
+      const contactListFilePath = `${userId}/contact-list/${timePrefix}-${sanitizeFileName(
+        contactListFile.name
+      )}`;
       const { error: uploadContactListError } = await supabase.storage
         .from(RESEARCH_ASSETS_BUCKET)
         .upload(contactListFilePath, contactListFile, { upsert: false });
 
       if (uploadContactListError) {
-        throw new Error(`Failed to upload contact list CSV: ${uploadContactListError.message}`);
+        throw new Error(
+          `Failed to upload contact list CSV: ${uploadContactListError.message}`
+        );
       }
 
-      const { error: insertError } = await supabase.from("research_campaigns").insert({
-        user_id: userId,
-        title,
-        description,
-        question_bank_mode: questionBankMode,
-        question_bank_text: questionBankMode === "text" ? questionBankText : null,
-        question_bank_file_name: questionBankMode === "file" && questionBankFile ? questionBankFile.name : null,
-        question_bank_file_path: questionBankMode === "file" ? questionBankFilePath : null,
-        question_bank_file_type: questionBankMode === "file" && questionBankFile ? questionBankFile.type || "application/pdf" : null,
-        contact_list_file_name: contactListFile.name,
-        contact_list_file_path: contactListFilePath,
-        contact_list_file_type: contactListFile.type || "text/csv",
-        timeline_start: new Date(startAt).toISOString(),
-        timeline_end: new Date(endAt).toISOString(),
-      });
+      const { error: insertError } = await supabase
+        .from("research_campaigns")
+        .insert({
+          user_id: userId,
+          title,
+          description,
+          question_bank_mode: questionBankMode,
+          question_bank_text:
+            questionBankMode === "text" ? questionBankText : null,
+          question_bank_file_name:
+            questionBankMode === "file" && questionBankFile
+              ? questionBankFile.name
+              : null,
+          question_bank_file_path:
+            questionBankMode === "file" ? questionBankFilePath : null,
+          question_bank_file_type:
+            questionBankMode === "file" && questionBankFile
+              ? questionBankFile.type || "application/pdf"
+              : null,
+          contact_list_file_name: contactListFile.name,
+          contact_list_file_path: contactListFilePath,
+          contact_list_file_type: contactListFile.type || "text/csv",
+          timeline_start: new Date(startAt).toISOString(),
+          timeline_end: new Date(endAt).toISOString(),
+        });
 
       if (insertError) {
-        throw new Error(`Failed to save research campaign: ${insertError.message}`);
+        throw new Error(
+          `Failed to save research campaign: ${insertError.message}`
+        );
       }
 
       setSuccessMessage("Research campaign created successfully.");
@@ -133,7 +160,8 @@ export default function ResearchCampaignModal({ isOpen, onClose }: ResearchCampa
         handleClose();
       }, 600);
     } catch (error) {
-      const fallbackMessage = "Unable to create research campaign. Please try again.";
+      const fallbackMessage =
+        "Unable to create research campaign. Please try again.";
       setErrorMessage(error instanceof Error ? error.message : fallbackMessage);
     } finally {
       setIsSubmitting(false);
@@ -172,17 +200,48 @@ export default function ResearchCampaignModal({ isOpen, onClose }: ResearchCampa
           boxShadow: "var(--shadow-lg)",
         }}
       >
-        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: "14px", marginBottom: "18px" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "flex-start",
+            justifyContent: "space-between",
+            gap: "14px",
+            marginBottom: "18px",
+          }}
+        >
           <div>
-            <h2 style={{ fontSize: "22px", fontWeight: 700, color: "var(--text-primary)", marginBottom: "6px" }}>
+            <h2
+              style={{
+                fontSize: "22px",
+                fontWeight: 700,
+                color: "var(--text-primary)",
+                marginBottom: "6px",
+              }}
+            >
               New Research Campaign
             </h2>
             <p style={{ fontSize: "14px", color: "var(--text-secondary)" }}>
-              Add background information on your research, initial contact list and prefered timeline.
+              Add background information on your research, initial contact list
+              and prefered timeline.
             </p>
           </div>
-          <button type="button" className="btn btn-ghost" style={{ padding: "8px", minWidth: "36px" }} onClick={handleClose} aria-label="Close modal">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <button
+            type="button"
+            className="btn btn-ghost"
+            style={{ padding: "8px", minWidth: "36px" }}
+            onClick={handleClose}
+            aria-label="Close modal"
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <path d="M18 6L6 18M6 6l12 12" />
             </svg>
           </button>
@@ -220,7 +279,14 @@ export default function ResearchCampaignModal({ isOpen, onClose }: ResearchCampa
               />
             </div>
 
-            <div className="card" style={{ padding: "16px", background: "var(--primary-subtle)", borderColor: "var(--border-light)" }}>
+            <div
+              className="card"
+              style={{
+                padding: "16px",
+                background: "var(--primary-subtle)",
+                borderColor: "var(--border-light)",
+              }}
+            >
               <div style={{ marginBottom: "12px" }}>
                 <label className="form-label" style={{ marginBottom: "4px" }}>
                   Question Bank
@@ -229,10 +295,16 @@ export default function ResearchCampaignModal({ isOpen, onClose }: ResearchCampa
                   Choose to enter questions directly or upload a PDF.
                 </p>
               </div>
-              <div style={{ display: "flex", gap: "8px", marginBottom: "12px" }}>
+              <div
+                style={{ display: "flex", gap: "8px", marginBottom: "12px" }}
+              >
                 <button
                   type="button"
-                  className={questionBankMode === "text" ? "btn btn-primary" : "btn btn-secondary"}
+                  className={
+                    questionBankMode === "text"
+                      ? "btn btn-primary"
+                      : "btn btn-secondary"
+                  }
                   style={{ fontSize: "13px", padding: "8px 14px" }}
                   onClick={() => {
                     setQuestionBankMode("text");
@@ -243,7 +315,11 @@ export default function ResearchCampaignModal({ isOpen, onClose }: ResearchCampa
                 </button>
                 <button
                   type="button"
-                  className={questionBankMode === "file" ? "btn btn-primary" : "btn btn-secondary"}
+                  className={
+                    questionBankMode === "file"
+                      ? "btn btn-primary"
+                      : "btn btn-secondary"
+                  }
                   style={{ fontSize: "13px", padding: "8px 14px" }}
                   onClick={() => setQuestionBankMode("file")}
                 >
@@ -274,7 +350,13 @@ export default function ResearchCampaignModal({ isOpen, onClose }: ResearchCampa
                       setQuestionBankFile(file);
                     }}
                   />
-                  <p style={{ fontSize: "12px", color: "var(--text-muted)", marginTop: "8px" }}>
+                  <p
+                    style={{
+                      fontSize: "12px",
+                      color: "var(--text-muted)",
+                      marginTop: "8px",
+                    }}
+                  >
                     Accepted format: PDF
                   </p>
                 </div>
@@ -297,16 +379,37 @@ export default function ResearchCampaignModal({ isOpen, onClose }: ResearchCampa
                   setContactListFile(file);
                 }}
               />
-              <p style={{ fontSize: "12px", color: "var(--text-muted)", marginTop: "8px" }}>
-                Upload columns like name, contact, age, occupation, and any custom fields you need.
+              <p
+                style={{
+                  fontSize: "12px",
+                  color: "var(--text-muted)",
+                  marginTop: "8px",
+                }}
+              >
+                Upload columns like name, contact, age, occupation, and any
+                custom fields you need.
               </p>
             </div>
 
             <div>
               <label className="form-label">Timeline</label>
-              <div style={{ display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: "12px" }}>
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+                  gap: "12px",
+                }}
+              >
                 <div>
-                  <p style={{ fontSize: "13px", color: "var(--text-secondary)", marginBottom: "6px" }}>Start</p>
+                  <p
+                    style={{
+                      fontSize: "13px",
+                      color: "var(--text-secondary)",
+                      marginBottom: "6px",
+                    }}
+                  >
+                    Start
+                  </p>
                   <input
                     className="input-base"
                     type="datetime-local"
@@ -316,7 +419,15 @@ export default function ResearchCampaignModal({ isOpen, onClose }: ResearchCampa
                   />
                 </div>
                 <div>
-                  <p style={{ fontSize: "13px", color: "var(--text-secondary)", marginBottom: "6px" }}>End</p>
+                  <p
+                    style={{
+                      fontSize: "13px",
+                      color: "var(--text-secondary)",
+                      marginBottom: "6px",
+                    }}
+                  >
+                    End
+                  </p>
                   <input
                     className="input-base"
                     type="datetime-local"
@@ -340,18 +451,39 @@ export default function ResearchCampaignModal({ isOpen, onClose }: ResearchCampa
                 border: "1px solid",
                 borderColor: errorMessage ? "var(--danger)" : "var(--success)",
                 color: errorMessage ? "#991B1B" : "#065F46",
-                background: errorMessage ? "var(--danger-light)" : "var(--success-light)",
+                background: errorMessage
+                  ? "var(--danger-light)"
+                  : "var(--success-light)",
               }}
             >
               {errorMessage || successMessage}
             </div>
           )}
 
-          <div style={{ display: "flex", justifyContent: "flex-end", gap: "10px", marginTop: "22px", paddingTop: "16px", paddingBottom: "50px", borderTop: "1px solid var(--border-light)" }}>
-            <button type="button" className="btn btn-secondary" onClick={handleClose} disabled={isSubmitting}>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "flex-end",
+              gap: "10px",
+              marginTop: "22px",
+              paddingTop: "16px",
+              paddingBottom: "50px",
+              borderTop: "1px solid var(--border-light)",
+            }}
+          >
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={handleClose}
+              disabled={isSubmitting}
+            >
               Cancel
             </button>
-            <button type="submit" className="btn btn-primary" disabled={isSubmitting}>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={isSubmitting}
+            >
               {isSubmitting ? "Creating..." : "Create Research Campaign"}
             </button>
           </div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.102.1",
-    "next": "16.1.6",
+    "next": "^16.2.3",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },


### PR DESCRIPTION
## Summary
Adds the research detail page, scaffolds the settings page, and refactors the dashboard to use the global design system.

## Changes
- `/dashboard/research/[id]` — full detail page with Overview, Calls, Transcripts, Contacts tabs
- `/dashboard/settings` — settings page scaffold
- `DashboardLayout` — Settings added to sidebar with active state
- `CampaignsPage` — live Supabase data replaces hardcoded mock campaigns
- `globals.css` — new utility classes: tab-bar, filter-pills, data-table, avatar, empty-state

## Test checklist
- [ ] Research detail page loads for a valid campaign UUID
- [ ] Tabs switch correctly (Overview / Calls / Transcripts / Contacts)
- [ ] Settings sidebar link highlights when on /dashboard/settings
- [ ] Campaign cards navigate to correct UUID routes
- [ ] No style regressions at mobile 375px